### PR TITLE
#5 Support TIMESTAMP types

### DIFF
--- a/carpet-record/build.gradle
+++ b/carpet-record/build.gradle
@@ -13,6 +13,7 @@ java {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/JavaType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/JavaType.java
@@ -89,6 +89,14 @@ public class JavaType {
         return typeName.equals("java.time.LocalTime");
     }
 
+    public boolean isLocalDateTime() {
+        return typeName.equals("java.time.LocalDateTime");
+    }
+
+    public boolean isInstant() {
+        return typeName.equals("java.time.Instant");
+    }
+
     public boolean isRecord() {
         return type.isRecord();
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
@@ -45,13 +45,16 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.impl.read.converter.BooleanGenericConverter;
+import com.jerolba.carpet.impl.read.converter.InstantConverter;
 import com.jerolba.carpet.impl.read.converter.LocalDateConverter;
+import com.jerolba.carpet.impl.read.converter.LocalDateTimeConverter;
 import com.jerolba.carpet.impl.read.converter.LocalTimeConverter;
 import com.jerolba.carpet.impl.read.converter.StringConverter;
 import com.jerolba.carpet.impl.read.converter.ToByteGenericConverter;
@@ -148,6 +151,13 @@ public class CarpetGroupAsMapConverter extends GroupConverter {
             }
             if (logicalType instanceof TimeLogicalTypeAnnotation time) {
                 return new LocalTimeConverter(consumer, time.getUnit());
+            }
+            if (logicalType instanceof TimestampLogicalTypeAnnotation timeStamp) {
+                if (timeStamp.isAdjustedToUTC()) {
+                    return new InstantConverter(consumer, timeStamp.getUnit());
+                } else {
+                    return new LocalDateTimeConverter(consumer, timeStamp.getUnit());
+                }
             }
             return new ToIntegerGenericConverter(consumer);
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
@@ -24,6 +24,7 @@ import java.lang.reflect.RecordComponent;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 
@@ -32,9 +33,11 @@ import com.jerolba.carpet.impl.JavaType;
 import com.jerolba.carpet.impl.read.ReadReflection.ConstructorParams;
 import com.jerolba.carpet.impl.read.converter.BooleanConverter;
 import com.jerolba.carpet.impl.read.converter.EnumConverter;
+import com.jerolba.carpet.impl.read.converter.InstantConverter;
 import com.jerolba.carpet.impl.read.converter.LocalDateConverter;
-import com.jerolba.carpet.impl.read.converter.StringConverter;
+import com.jerolba.carpet.impl.read.converter.LocalDateTimeConverter;
 import com.jerolba.carpet.impl.read.converter.LocalTimeConverter;
+import com.jerolba.carpet.impl.read.converter.StringConverter;
 import com.jerolba.carpet.impl.read.converter.ToByteConverter;
 import com.jerolba.carpet.impl.read.converter.ToDoubleConverter;
 import com.jerolba.carpet.impl.read.converter.ToFloatConverter;
@@ -95,6 +98,13 @@ class PrimitiveConverterFactory {
         }
         if (type.isLocalTime() && parquetField.getLogicalTypeAnnotation() instanceof TimeLogicalTypeAnnotation time) {
             return new LocalTimeConverter(obj -> constructor.c[index] = obj, time.getUnit());
+        }
+        if (parquetField.getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation timeStamp) {
+            if (type.isLocalDateTime()) {
+                return new LocalDateTimeConverter(obj -> constructor.c[index] = obj, timeStamp.getUnit());
+            } else if (type.isInstant()) {
+                return new InstantConverter(obj -> constructor.c[index] = obj, timeStamp.getUnit());
+            }
         }
         throw new RecordTypeConversionException(
                 type.getTypeName() + " not compatible with " + recordComponent.getName() + " field");

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveGenericConverterFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveGenericConverterFactory.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 
@@ -32,13 +33,15 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.impl.JavaType;
 import com.jerolba.carpet.impl.read.converter.BooleanGenericConverter;
 import com.jerolba.carpet.impl.read.converter.EnumConverter;
-import com.jerolba.carpet.impl.read.converter.StringConverter;
+import com.jerolba.carpet.impl.read.converter.InstantConverter;
+import com.jerolba.carpet.impl.read.converter.LocalDateConverter;
+import com.jerolba.carpet.impl.read.converter.LocalDateTimeConverter;
 import com.jerolba.carpet.impl.read.converter.LocalTimeConverter;
+import com.jerolba.carpet.impl.read.converter.StringConverter;
 import com.jerolba.carpet.impl.read.converter.ToByteGenericConverter;
 import com.jerolba.carpet.impl.read.converter.ToDoubleGenericConverter;
 import com.jerolba.carpet.impl.read.converter.ToFloatGenericConverter;
 import com.jerolba.carpet.impl.read.converter.ToIntegerGenericConverter;
-import com.jerolba.carpet.impl.read.converter.LocalDateConverter;
 import com.jerolba.carpet.impl.read.converter.ToLongGenericConverter;
 import com.jerolba.carpet.impl.read.converter.ToShortGenericConverter;
 import com.jerolba.carpet.impl.read.converter.UuidToStringConverter;
@@ -89,6 +92,13 @@ class PrimitiveGenericConverterFactory {
         if ((primitive == PrimitiveTypeName.INT32 || primitive == PrimitiveTypeName.INT64) && type.isLocalTime()
                 && logicalTypeAnnotation instanceof TimeLogicalTypeAnnotation time) {
             return new LocalTimeConverter(consumer, time.getUnit());
+        }
+        if (logicalTypeAnnotation instanceof TimestampLogicalTypeAnnotation timeStamp) {
+            if (type.isLocalDateTime()) {
+                return new LocalDateTimeConverter(consumer, timeStamp.getUnit());
+            } else if (type.isInstant()) {
+                return new InstantConverter(consumer, timeStamp.getUnit());
+            }
         }
         throw new RecordTypeConversionException(
                 type.getTypeName() + " not compatible with " + schemaType.getName() + " collection");

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -29,6 +29,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
@@ -131,6 +132,11 @@ public class SchemaValidation {
         LogicalTypeAnnotation logicalTypeAnnotation = primitiveType.getLogicalTypeAnnotation();
         if (type.isLocalTime() && logicalTypeAnnotation instanceof TimeLogicalTypeAnnotation time
                 && (time.getUnit() == TimeUnit.MICROS || time.getUnit() == TimeUnit.NANOS)) {
+            return true;
+        }
+        if ((type.isLocalDateTime() || type.isInstant())
+                && logicalTypeAnnotation instanceof TimestampLogicalTypeAnnotation timeStamp) {
+            // TODO: add logic to fail about isAdjustedToUTC conversion
             return true;
         }
         return throwInvalidConversionException(primitiveType, type);

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/InstantConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/InstantConverter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.read.converter;
+
+import java.time.Instant;
+import java.util.function.Consumer;
+
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+
+import com.jerolba.carpet.impl.read.converter.InstantRead.LongToInstant;
+
+public class InstantConverter extends PrimitiveConverter {
+
+    private final Consumer<Object> consumer;
+    private final LongToInstant mapper;
+    private Instant[] dict = null;
+
+    public InstantConverter(Consumer<Object> consumer, TimeUnit timeUnit) {
+        this.consumer = consumer;
+        this.mapper = switch (timeUnit) {
+        case MILLIS -> InstantRead::instantFromMillisFromEpoch;
+        case MICROS -> InstantRead::instantFromMicrosFromEpoch;
+        case NANOS -> InstantRead::instantFromNanosFromEpoch;
+        };
+    }
+
+    @Override
+    public void addLong(long timeToEpoch) {
+        consumer.accept(mapper.map(timeToEpoch));
+    }
+
+    @Override
+    public void addValueFromDictionary(int dictionaryId) {
+        consumer.accept(dict[dictionaryId]);
+    }
+
+    @Override
+    public boolean hasDictionarySupport() {
+        return true;
+    }
+
+    @Override
+    public void setDictionary(Dictionary dictionary) {
+        int maxId = dictionary.getMaxId();
+        dict = new Instant[maxId + 1];
+        for (int i = 0; i <= maxId; i++) {
+            dict[i] = mapper.map(dictionary.decodeToLong(i));
+        }
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/InstantRead.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/InstantRead.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.read.converter;
+
+import java.time.Instant;
+
+class InstantRead {
+
+    @FunctionalInterface
+    public interface LongToInstant {
+        Instant map(long timeFromEpoch);
+    }
+
+    public static Instant instantFromMillisFromEpoch(long millisFromEpoch) {
+        return Instant.ofEpochMilli(millisFromEpoch);
+    }
+
+    public static Instant instantFromMicrosFromEpoch(long microsFromEpoch) {
+        long secs = Math.floorDiv(microsFromEpoch, 1_000_000L);
+        long nanos = Math.floorMod(microsFromEpoch, 1_000_000L) * 1000L;
+        return Instant.ofEpochSecond(secs, nanos);
+    }
+
+    public static Instant instantFromNanosFromEpoch(long nanosFromEpoch) {
+        long secs = Math.floorDiv(nanosFromEpoch, 1_000_000_000L);
+        long nanos = Math.floorMod(nanosFromEpoch, 1_000_000_000L);
+        return Instant.ofEpochSecond(secs, nanos);
+    }
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeConverter.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.read.converter;
+
+import java.time.LocalDateTime;
+import java.util.function.Consumer;
+
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+
+import com.jerolba.carpet.impl.read.converter.LocalDateTimeRead.LongToLocalDateTime;
+
+public class LocalDateTimeConverter extends PrimitiveConverter {
+
+    private final Consumer<Object> consumer;
+    private final LongToLocalDateTime mapper;
+    private LocalDateTime[] dict = null;
+
+    public LocalDateTimeConverter(Consumer<Object> consumer, TimeUnit timeUnit) {
+        this.consumer = consumer;
+        this.mapper = switch (timeUnit) {
+        case MILLIS -> LocalDateTimeRead::localDateTimeFromMillisFromEpoch;
+        case MICROS -> LocalDateTimeRead::localDateTimeFromMicrosFromEpoch;
+        case NANOS -> LocalDateTimeRead::localDateTimeFromNanosFromEpoch;
+        };
+    }
+
+    @Override
+    public void addLong(long timeToEpoch) {
+        consumer.accept(mapper.map(timeToEpoch));
+    }
+
+    @Override
+    public void addValueFromDictionary(int dictionaryId) {
+        consumer.accept(dict[dictionaryId]);
+    }
+
+    @Override
+    public boolean hasDictionarySupport() {
+        return true;
+    }
+
+    @Override
+    public void setDictionary(Dictionary dictionary) {
+        int maxId = dictionary.getMaxId();
+        dict = new LocalDateTime[maxId + 1];
+        for (int i = 0; i <= maxId; i++) {
+            dict[i] = mapper.map(dictionary.decodeToLong(i));
+        }
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeRead.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeRead.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.read.converter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public class LocalDateTimeRead {
+
+    @FunctionalInterface
+    public interface LongToLocalDateTime {
+        LocalDateTime map(long timeFromEpoch);
+    }
+
+    public static LocalDateTime localDateTimeFromMillisFromEpoch(long millisFromEpoch) {
+        Instant instant = InstantRead.instantFromMillisFromEpoch(millisFromEpoch);
+        return localDateTimeInUTC(instant);
+    }
+
+    public static LocalDateTime localDateTimeFromMicrosFromEpoch(long microsFromEpoch) {
+        Instant instant = InstantRead.instantFromMicrosFromEpoch(microsFromEpoch);
+        return localDateTimeInUTC(instant);
+    }
+
+    public static LocalDateTime localDateTimeFromNanosFromEpoch(long nanosFromEpoch) {
+        Instant instant = InstantRead.instantFromNanosFromEpoch(nanosFromEpoch);
+        return localDateTimeInUTC(instant);
+    }
+
+    private static LocalDateTime localDateTimeInUTC(Instant instant) {
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/InstantWrite.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/InstantWrite.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import java.time.Instant;
+
+class InstantWrite {
+
+    @FunctionalInterface
+    public interface InstantToLong {
+        long map(Instant instant);
+    }
+
+    public static long millisFromEpochFromInstant(Instant instant) {
+        return instant.toEpochMilli();
+    }
+
+    public static long microsFromEpochFromInstant(Instant instant) {
+        long seconds = instant.getEpochSecond();
+        int nanos = instant.getNano();
+
+        // Same implementation than Instant.toEpochMilli, but with 1_000_000L
+        if (seconds < 0 && nanos > 0) {
+            long micros = Math.multiplyExact(seconds + 1, 1_000_000L);
+            long adjustment = (nanos / 1_000L) - 1_000_000L;
+            return Math.addExact(micros, adjustment);
+        } else {
+            long micros = Math.multiplyExact(seconds, 1_000_000L);
+            return Math.addExact(micros, nanos / 1_000L);
+        }
+    }
+
+    public static long nanosFromEpochFromInstant(Instant instant) {
+        long seconds = instant.getEpochSecond();
+        int nanos = instant.getNano();
+
+        // Same implementation than Instant.toEpochMilli, but with 1_000_000_000L
+        if (seconds < 0 && nanos > 0) {
+            long micros = Math.multiplyExact(seconds + 1, 1_000_000_000L);
+            long adjustment = nanos - 1_000_000_000L;
+            return Math.addExact(micros, adjustment);
+        } else {
+            long micros = Math.multiplyExact(seconds, 1_000_000_000L);
+            return Math.addExact(micros, nanos);
+        }
+    }
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -23,6 +23,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
@@ -254,6 +255,16 @@ public class JavaRecord2Schema {
             case MILLIS -> Types.primitive(PrimitiveTypeName.INT32, repetition).as(timeType).named(name);
             case MICROS, NANOS -> Types.primitive(PrimitiveTypeName.INT64, repetition).as(timeType).named(name);
             };
+        }
+        if (javaType.isLocalDateTime()) {
+            var timeUnit = carpetConfiguration.defaultTimeUnit();
+            var timeStampType = timestampType(false, toParquetTimeUnit(timeUnit));
+            return Types.primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
+        }
+        if (javaType.isInstant()) {
+            var timeUnit = carpetConfiguration.defaultTimeUnit();
+            var timeStampType = timestampType(true, toParquetTimeUnit(timeUnit));
+            return Types.primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
         }
         return null;
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/LocalDateTimeWrite.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/LocalDateTimeWrite.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+class LocalDateTimeWrite {
+
+    @FunctionalInterface
+    public interface LocalDateTimeToLong {
+        long map(LocalDateTime localdateTime);
+    }
+
+    public static long millisFromEpochFromLocalDateTime(LocalDateTime localDateTime) {
+        Instant instant = timestampInUTCOffset(localDateTime);
+        return InstantWrite.millisFromEpochFromInstant(instant);
+    }
+
+    public static long microsFromEpochFromLocalDateTime(LocalDateTime localDateTime) {
+        Instant instant = timestampInUTCOffset(localDateTime);
+        return InstantWrite.microsFromEpochFromInstant(instant);
+    }
+
+    public static long nanosFromEpochFromLocalDateTime(LocalDateTime localDateTime) {
+        Instant instant = timestampInUTCOffset(localDateTime);
+        return InstantWrite.nanosFromEpochFromInstant(instant);
+    }
+
+    private static Instant timestampInUTCOffset(LocalDateTime timestamp) {
+        return timestamp.toInstant(ZoneOffset.UTC);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/SimpleCollectionItemConsumerFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/SimpleCollectionItemConsumerFactory.java
@@ -15,9 +15,17 @@
  */
 package com.jerolba.carpet.impl.write;
 
+import static com.jerolba.carpet.impl.write.InstantWrite.microsFromEpochFromInstant;
+import static com.jerolba.carpet.impl.write.InstantWrite.millisFromEpochFromInstant;
+import static com.jerolba.carpet.impl.write.InstantWrite.nanosFromEpochFromInstant;
+import static com.jerolba.carpet.impl.write.LocalDateTimeWrite.microsFromEpochFromLocalDateTime;
+import static com.jerolba.carpet.impl.write.LocalDateTimeWrite.millisFromEpochFromLocalDateTime;
+import static com.jerolba.carpet.impl.write.LocalDateTimeWrite.nanosFromEpochFromLocalDateTime;
 import static com.jerolba.carpet.impl.write.UuidWrite.uuidToBinary;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.function.BiConsumer;
 
@@ -68,6 +76,20 @@ public class SimpleCollectionItemConsumerFactory {
             case MILLIS -> (consumer, v) -> consumer.addInteger((int) (nanoTime(v) / 1_000_000L));
             case MICROS -> (consumer, v) -> consumer.addLong(nanoTime(v) / 1_000L);
             case NANOS -> (consumer, v) -> consumer.addLong(nanoTime(v));
+            };
+        }
+        if (type.isLocalDateTime()) {
+            return switch (carpetConfiguration.defaultTimeUnit()) {
+            case MILLIS -> (consumer, v) -> consumer.addLong(millisFromEpochFromLocalDateTime((LocalDateTime) v));
+            case MICROS -> (consumer, v) -> consumer.addLong(microsFromEpochFromLocalDateTime((LocalDateTime) v));
+            case NANOS -> (consumer, v) -> consumer.addLong(nanosFromEpochFromLocalDateTime((LocalDateTime) v));
+            };
+        }
+        if (type.isInstant()) {
+            return switch (carpetConfiguration.defaultTimeUnit()) {
+            case MILLIS -> (consumer, v) -> consumer.addLong(millisFromEpochFromInstant((Instant) v));
+            case MICROS -> (consumer, v) -> consumer.addLong(microsFromEpochFromInstant((Instant) v));
+            case NANOS -> (consumer, v) -> consumer.addLong(nanosFromEpochFromInstant((Instant) v));
             };
         }
         if (type.isRecord()) {

--- a/carpet-record/src/test/java/com/jerolba/carpet/ParquetReaderTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/ParquetReaderTest.java
@@ -18,6 +18,8 @@ package com.jerolba.carpet;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -75,6 +77,9 @@ public class ParquetReaderTest {
     }
 
     public <T> ParquetReader<T> getCarpetReader(Class<T> readType, ReadFlag... flags) throws IOException {
+        // Every file must be readed to a Map
+        List<Map> list = new CarpetReader<>(new File(path), Map.class).toList();
+
         InputFile inputFile = new FileSystemInputFile(new File(path));
         Builder<T> builder = CarpetParquetReader.builder(inputFile, readType);
         for (ReadFlag f : flags) {

--- a/carpet-record/src/test/java/com/jerolba/carpet/ParquetWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/ParquetWriterTest.java
@@ -91,8 +91,12 @@ public class ParquetWriterTest<T> {
     }
 
     public ParquetReader<GenericRecord> getAvroGenericRecordReader() throws IOException {
+        return getAvroGenericRecordReaderWithModel(GenericData.get());
+    }
+
+    public ParquetReader<GenericRecord> getAvroGenericRecordReaderWithModel(GenericData model) throws IOException {
         return AvroParquetReader.<GenericRecord>builder(new FileSystemInputFile(getTestFile()))
-                .withDataModel(GenericData.get())
+                .withDataModel(model)
                 .build();
     }
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/JavaRecord2SchemaTest.java
@@ -21,7 +21,9 @@ import static com.jerolba.carpet.TimeUnit.NANOS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +124,7 @@ class JavaRecord2SchemaTest {
 
     @Test
     void dateTypesRecordTest() {
-        record DateTypesRecord(LocalDate localDate, LocalTime localTime) {
+        record DateTypesRecord(LocalDate localDate, LocalTime localTime, Instant instant, LocalDateTime localDateTime) {
         }
 
         MessageType schema = defaultConfigSchema.createSchema(DateTypesRecord.class);
@@ -130,6 +132,8 @@ class JavaRecord2SchemaTest {
                 message DateTypesRecord {
                   optional int32 localDate (DATE);
                   optional int32 localTime (TIME(MILLIS,true));
+                  optional int64 instant (TIMESTAMP(MILLIS,true));
+                  optional int64 localDateTime (TIMESTAMP(MILLIS,false));
                 }
                 """;
         assertEquals(expected, schema.toString());
@@ -180,6 +184,102 @@ class JavaRecord2SchemaTest {
             assertEquals(expected, schema.toString());
         }
 
+    }
+
+    @Nested
+    class TimeStampDefinition {
+
+        @Nested
+        class InstantDefinition {
+
+            record TimeStampRecord(Instant instant) {
+            }
+
+            @Test
+            void millis() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, MILLIS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(MILLIS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void micros() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, MICROS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(MICROS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void nanos() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, NANOS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(NANOS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+        }
+
+        @Nested
+        class LocalDateTimeDefinition {
+
+            record TimeStampRecord(LocalDateTime localdDateTime) {
+            }
+
+            @Test
+            void millis() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, MILLIS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(MILLIS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void micros() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, MICROS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(MICROS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void nanos() {
+                var cfg = new CarpetWriteConfiguration(AnnotatedLevels.THREE, defaultNaming, NANOS);
+                var schemaMapper = new JavaRecord2Schema(cfg);
+                MessageType schema = schemaMapper.createSchema(TimeStampRecord.class);
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(NANOS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
`Instant` is converted to TIMESTAMP with isAdjustedToUTC = true 
`LocalDateTime` is converted to TIMESTAMP with isAdjustedToUTC = false

Read isAdjustedToUTC = true and map to `Instant` and the opposite doesn't generate an error.