### PR TITLE
#57 Create Write Model system

### DIFF
--- a/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.thirdparty.com.google.common.annotations.Beta;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.compression.CompressionCodecFactory;
@@ -40,6 +41,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
 
 import com.jerolba.carpet.io.OutputStreamOutputFile;
+import com.jerolba.carpet.model.WriteRecordModelType;
 
 /**
  * A Parquet file writer for writing java records of type T to a file or output
@@ -528,6 +530,7 @@ public class CarpetWriter<T> implements Closeable, Consumer<T> {
          */
         public Builder<T> config(String property, String value) {
             builder.config(property, value);
+            parquetConfProvided = true;
             return this;
         }
 
@@ -630,6 +633,39 @@ public class CarpetWriter<T> implements Closeable, Consumer<T> {
          */
         public Builder<T> withBigDecimalScaleAdjustment(RoundingMode roundingMode) {
             builder.withBigDecimalScaleAdjustment(roundingMode);
+            return this;
+        }
+
+        /**
+         * Configures the factory of the write data model to use, instead of default
+         * record convention. The factory receives all configuration to decide how to
+         * build the WriteRecordModelType.
+         *
+         * Experimental feature to support custom data models different from record,
+         * like classes or DataFrames
+         *
+         * @param writeModelFactory creates WriteRecordModelType given configuration
+         *                          specific to Carpet and Parquet
+         * @return this builder for method chaining.
+         */
+        @Beta
+        public Builder<T> withWriteRecordModel(WriteModelFactory<T> writeModelFactory) {
+            builder.withWriteRecordModel(writeModelFactory);
+            return this;
+        }
+
+        /**
+         * Configures write data model to use, instead of default record convention.
+         *
+         * Experimental feature to support custom data models different from record,
+         * like classes or DataFrames
+         *
+         * @param rootWriteRecordModel write record model to use
+         * @return this builder for method chaining.
+         */
+        @Beta
+        public Builder<T> withWriteRecordModel(WriteRecordModelType<T> rootWriteRecordModel) {
+            builder.withWriteRecordModel(rootWriteRecordModel);
             return this;
         }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/WriteModelFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/WriteModelFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet;
+
+import org.apache.parquet.conf.ParquetConfiguration;
+
+import com.jerolba.carpet.impl.write.CarpetWriteConfiguration;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+@FunctionalInterface
+public interface WriteModelFactory<T> {
+
+    record WriteConfigurationContext(CarpetWriteConfiguration carpetWriteConfiguration,
+            ParquetConfiguration parquetConfiguration) {
+    }
+
+    WriteRecordModelType<T> create(Class<T> writeClass, WriteConfigurationContext writeConfigurationContext);
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import com.jerolba.carpet.model.BigDecimalType;
+import com.jerolba.carpet.model.BooleanType;
+import com.jerolba.carpet.model.ByteType;
+import com.jerolba.carpet.model.DoubleType;
+import com.jerolba.carpet.model.EnumType;
+import com.jerolba.carpet.model.FieldType;
+import com.jerolba.carpet.model.FloatType;
+import com.jerolba.carpet.model.InstantType;
+import com.jerolba.carpet.model.IntegerType;
+import com.jerolba.carpet.model.ListType;
+import com.jerolba.carpet.model.LocalDateTimeType;
+import com.jerolba.carpet.model.LocalDateType;
+import com.jerolba.carpet.model.LocalTimeType;
+import com.jerolba.carpet.model.LongType;
+import com.jerolba.carpet.model.MapType;
+import com.jerolba.carpet.model.SetType;
+import com.jerolba.carpet.model.ShortType;
+import com.jerolba.carpet.model.StringType;
+import com.jerolba.carpet.model.UuidType;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+class FieldTypeInspect {
+
+    private final FieldType fieldType;
+
+    public FieldTypeInspect(FieldType fieldType) {
+        this.fieldType = fieldType;
+    }
+
+    public boolean isInteger() {
+        return fieldType instanceof IntegerType;
+    }
+
+    public boolean isLong() {
+        return fieldType instanceof LongType;
+    }
+
+    public boolean isShort() {
+        return fieldType instanceof ShortType;
+    }
+
+    public boolean isByte() {
+        return fieldType instanceof ByteType;
+    }
+
+    public boolean isDouble() {
+        return fieldType instanceof DoubleType;
+    }
+
+    public boolean isFloat() {
+        return fieldType instanceof FloatType;
+    }
+
+    public boolean isBoolean() {
+        return fieldType instanceof BooleanType;
+    }
+
+    public boolean isString() {
+        return fieldType instanceof StringType;
+    }
+
+    public boolean isEnum() {
+        return fieldType instanceof EnumType;
+    }
+
+    public boolean isUuid() {
+        return fieldType instanceof UuidType;
+    }
+
+    public boolean isBigDecimal() {
+        return fieldType instanceof BigDecimalType;
+    }
+
+    public boolean isLocalDate() {
+        return fieldType instanceof LocalDateType;
+    }
+
+    public boolean isLocalTime() {
+        return fieldType instanceof LocalTimeType;
+    }
+
+    public boolean isLocalDateTime() {
+        return fieldType instanceof LocalDateTimeType;
+    }
+
+    public boolean isInstant() {
+        return fieldType instanceof InstantType;
+    }
+
+    public boolean isRecord() {
+        return fieldType instanceof WriteRecordModelType;
+    }
+
+    public boolean isCollection() {
+        return fieldType instanceof ListType || fieldType instanceof SetType;
+    }
+
+    public boolean isMap() {
+        return fieldType instanceof MapType;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static com.jerolba.carpet.impl.NotNullField.isNotNull;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+
+import java.lang.reflect.TypeVariable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.impl.JavaType;
+import com.jerolba.carpet.impl.Parameterized;
+import com.jerolba.carpet.impl.ParameterizedCollection;
+import com.jerolba.carpet.impl.ParameterizedMap;
+import com.jerolba.carpet.model.EnumType;
+import com.jerolba.carpet.model.FieldType;
+import com.jerolba.carpet.model.FieldTypes;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+public class JavaRecord2WriteModel {
+
+    private final com.jerolba.carpet.impl.write.FieldToColumnMapper fieldToColumnMapper;
+
+    public JavaRecord2WriteModel(CarpetWriteConfiguration carpetConfiguration) {
+        this.fieldToColumnMapper = new com.jerolba.carpet.impl.write.FieldToColumnMapper(
+                carpetConfiguration.columnNamingStrategy());
+    }
+
+    public <T> WriteRecordModelType<T> createModel(Class<T> recordClass) {
+        return buildRecordModel(recordClass, new HashSet<>());
+    }
+
+    private <T> WriteRecordModelType<T> buildRecordModel(Class<T> classToModel, Set<Class<?>> visited) {
+        visited = validateNotVisitedRecord(classToModel, visited);
+
+        WriteRecordModelType<T> writeModel = writeRecordModel(classToModel);
+        createRecordFields(writeModel, classToModel, visited);
+        return writeModel;
+    }
+
+    private <T> void createRecordFields(WriteRecordModelType<T> writeModel, Class<T> recordClass,
+            Set<Class<?>> visited) {
+
+        for (var attr : recordClass.getRecordComponents()) {
+            java.lang.reflect.Type genericType = attr.getGenericType();
+            if (genericType instanceof TypeVariable<?>) {
+                throw new RecordTypeConversionException(genericType.toString() + " generic types not supported");
+            }
+            Class<?> type = attr.getType();
+            JavaType javaType = new JavaType(type);
+            FieldType fieldType = null;
+            if (javaType.isCollection()) {
+                var parameterizedCollection = Parameterized.getParameterizedCollection(attr);
+                fieldType = createCollectionType(parameterizedCollection, visited);
+            } else if (javaType.isMap()) {
+                var parameterizedMap = Parameterized.getParameterizedMap(attr);
+                fieldType = createMapType(parameterizedMap, visited);
+            } else {
+                boolean notNull = type.isPrimitive() || isNotNull(attr);
+                fieldType = simpleOrCompositeClass(type, notNull, visited);
+            }
+            String fieldName = fieldToColumnMapper.getColumnName(attr);
+            Function<T, Object> recordAccessor = (Function<T, Object>) Reflection.recordAccessor(recordClass, attr);
+            writeModel.withField(fieldName, fieldType, recordAccessor);
+        }
+    }
+
+    private FieldType simpleOrCompositeClass(Class<?> type, boolean isPrimitive, Set<Class<?>> visited) {
+        FieldType simple = buildSimpleType(type, isPrimitive);
+        return simple == null ? buildRecordModel(type, visited) : simple;
+    }
+
+    private FieldType createCollectionType(ParameterizedCollection parametized, Set<Class<?>> visited) {
+        if (parametized.isCollection()) {
+            return LIST.ofType(createCollectionType(parametized.getParametizedAsCollection(), visited));
+        } else if (parametized.isMap()) {
+            return LIST.ofType(createMapType(parametized.getParametizedAsMap(), visited));
+        }
+        return LIST.ofType(simpleOrCompositeClass(parametized.getActualType(), false, visited));
+    }
+
+    private FieldType createMapType(ParameterizedMap parametized, Set<Class<?>> visited) {
+        Class<?> keyType = parametized.getKeyActualType();
+        if (parametized.keyIsCollection() || parametized.keyIsMap()) {
+            throw new RuntimeException("Maps with collections or maps as keys are not supported");
+        }
+        FieldType nestedKey = simpleOrCompositeClass(keyType, false, visited);
+
+        if (parametized.valueIsCollection()) {
+            FieldType childCollection = createCollectionType(parametized.getValueTypeAsCollection(), visited);
+            return MAP.ofTypes(nestedKey, childCollection);
+        } else if (parametized.valueIsMap()) {
+            FieldType childMap = createMapType(parametized.getValueTypeAsMap(), visited);
+            return MAP.ofTypes(nestedKey, childMap);
+        }
+        FieldType nestedValue = simpleOrCompositeClass(parametized.getValueActualType(), false, visited);
+        if (nestedKey != null && nestedValue != null) {
+            return MAP.ofTypes(nestedKey, nestedValue);
+        }
+        throw new RecordTypeConversionException("Unsuported type in Map");
+    }
+
+    private Set<Class<?>> validateNotVisitedRecord(Class<?> recordClass, Set<Class<?>> visited) {
+        if (!recordClass.isRecord()) {
+            throw new RecordTypeConversionException(recordClass.getName() + " must be a java Record");
+        }
+        if (visited.contains(recordClass)) {
+            throw new RecordTypeConversionException("Recusive classes are not supported");
+        }
+        visited = new HashSet<>(visited);
+        visited.add(recordClass);
+        return visited;
+    }
+
+    public static FieldType buildSimpleType(Class<?> type, boolean isPrimitive) {
+        JavaType javaType = new JavaType(type);
+        FieldType javaPrimitiveType = javaPrimitiveTypes(javaType, isPrimitive);
+        return javaPrimitiveType != null ? javaPrimitiveType : javaTypes(type, javaType);
+    }
+
+    private static FieldType javaPrimitiveTypes(JavaType javaType, boolean isPrimitive) {
+        if (javaType.isInteger()) {
+            return isPrimitive ? FieldTypes.INTEGER.notNull() : FieldTypes.INTEGER;
+        }
+        if (javaType.isLong()) {
+            return isPrimitive ? FieldTypes.LONG.notNull() : FieldTypes.LONG;
+        }
+        if (javaType.isFloat()) {
+            return isPrimitive ? FieldTypes.FLOAT.notNull() : FieldTypes.FLOAT;
+        }
+        if (javaType.isDouble()) {
+            return isPrimitive ? FieldTypes.DOUBLE.notNull() : FieldTypes.DOUBLE;
+        }
+        if (javaType.isBoolean()) {
+            return isPrimitive ? FieldTypes.BOOLEAN.notNull() : FieldTypes.BOOLEAN;
+        }
+        if (javaType.isShort()) {
+            return isPrimitive ? FieldTypes.SHORT.notNull() : FieldTypes.SHORT;
+        }
+        if (javaType.isByte()) {
+            return isPrimitive ? FieldTypes.BYTE.notNull() : FieldTypes.BYTE;
+        }
+        return null;
+    }
+
+    private static FieldType javaTypes(Class<?> type, JavaType javaType) {
+        if (javaType.isString()) {
+            return FieldTypes.STRING;
+        }
+        if (javaType.isEnum()) {
+            return new EnumType(false, (Class<? extends Enum<?>>) type);
+        }
+        if (javaType.isUuid()) {
+            return FieldTypes.UUID;
+        }
+        if (javaType.isBigDecimal()) {
+            return FieldTypes.BIG_DECIMAL;
+        }
+        if (javaType.isLocalDate()) {
+            return FieldTypes.LOCAL_DATE;
+        }
+        if (javaType.isLocalTime()) {
+            return FieldTypes.LOCAL_TIME;
+        }
+        if (javaType.isLocalDateTime()) {
+            return FieldTypes.LOCAL_DATE_TIME;
+        }
+        if (javaType.isInstant()) {
+            return FieldTypes.INSTANT;
+        }
+        return null;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static com.jerolba.carpet.impl.write.TimeWrite.instantCosumer;
+import static com.jerolba.carpet.impl.write.TimeWrite.localDateTimeConsumer;
+import static com.jerolba.carpet.impl.write.TimeWrite.localTimeConsumer;
+import static com.jerolba.carpet.impl.write.UuidWrite.uuidToBinary;
+
+import java.time.LocalDate;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.RecordConsumer;
+
+import com.jerolba.carpet.model.EnumType;
+import com.jerolba.carpet.model.FieldType;
+import com.jerolba.carpet.model.ToBooleanFunction;
+import com.jerolba.carpet.model.ToByteFunction;
+import com.jerolba.carpet.model.ToFloatFunction;
+import com.jerolba.carpet.model.ToShortFunction;
+import com.jerolba.carpet.model.WriteRecordModelType;
+import com.jerolba.carpet.model.WriteRecordModelType.PrimitiveJavaFieldInfo;
+
+class ModelFieldsWriter {
+
+    public static BiConsumer<RecordConsumer, Object> buildSimpleElementConsumer(FieldType fieldType,
+            RecordConsumer recordConsumer, CarpetWriteConfiguration carpetConfiguration) {
+
+        var type = new FieldTypeInspect(fieldType);
+        if (type.isInteger()) {
+            return (consumer, v) -> consumer.addInteger((Integer) v);
+        }
+        if (type.isString()) {
+            return (consumer, v) -> consumer.addBinary(Binary.fromString((String) v));
+        }
+        if (type.isBoolean()) {
+            return (consumer, v) -> consumer.addBoolean((Boolean) v);
+        }
+        if (type.isLong()) {
+            return (consumer, v) -> consumer.addLong((Long) v);
+        }
+        if (type.isDouble()) {
+            return (consumer, v) -> consumer.addDouble((Double) v);
+        }
+        if (type.isFloat()) {
+            return (consumer, v) -> consumer.addFloat((Float) v);
+        }
+        if (type.isShort() || type.isByte()) {
+            return (consumer, v) -> consumer.addInteger(((Number) v).intValue());
+        }
+        if (fieldType instanceof EnumType enumType) {
+            EnumsValues enumValues = new EnumsValues(enumType.enumClass());
+            return (consumer, v) -> consumer.addBinary(enumValues.getValue(v));
+        }
+        if (type.isUuid()) {
+            return (consumer, v) -> consumer.addBinary(uuidToBinary(v));
+        }
+        if (type.isLocalDate()) {
+            return (consumer, v) -> consumer.addInteger((int) ((LocalDate) v).toEpochDay());
+        }
+        if (type.isLocalTime()) {
+            return localTimeConsumer(carpetConfiguration.defaultTimeUnit());
+        }
+        if (type.isLocalDateTime()) {
+            return localDateTimeConsumer(carpetConfiguration.defaultTimeUnit());
+        }
+        if (type.isInstant()) {
+            return instantCosumer(carpetConfiguration.defaultTimeUnit());
+        }
+        if (type.isBigDecimal()) {
+            return new BigDecimalWrite(carpetConfiguration.decimalConfig())::write;
+        }
+        if (fieldType instanceof WriteRecordModelType<?> recordType) {
+            var recordWriter = new WriteRecordModelWriter(recordConsumer, recordType, carpetConfiguration);
+            return (consumer, v) -> {
+                consumer.startGroup();
+                recordWriter.write(v);
+                consumer.endGroup();
+            };
+        }
+        return null;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static Consumer<Object> buildPrimitiveJavaConsumer(PrimitiveJavaFieldInfo<?> primitiveField,
+            int idx, RecordConsumer recordConsumer) {
+        String parquetFieldName = primitiveField.parquetFieldName();
+        var javaType = new FieldTypeInspect(primitiveField.fieldType());
+        if (javaType.isBoolean()) {
+            var accessor = (ToBooleanFunction) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addBoolean(accessor.applyAsBoolean(obj)));
+        } else if (javaType.isByte()) {
+            var accessor = (ToByteFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addInteger(accessor.applyAsByte(obj)));
+        } else if (javaType.isShort()) {
+            var accessor = (ToShortFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addInteger(accessor.applyAsShort(obj)));
+        } else if (javaType.isInteger()) {
+            var accessor = (ToIntFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addInteger(accessor.applyAsInt(obj)));
+        } else if (javaType.isLong()) {
+            var accessor = (ToLongFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addLong(accessor.applyAsLong(obj)));
+        } else if (javaType.isFloat()) {
+            var accessor = (ToFloatFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addFloat(accessor.applyAsFloat(obj)));
+        } else if (javaType.isDouble()) {
+            var accessor = (ToDoubleFunction<Object>) primitiveField.accessor();
+            return new PrimitiveFieldWriter(recordConsumer, parquetFieldName, idx,
+                    (rc, obj) -> rc.addDouble(accessor.applyAsDouble(obj)));
+        }
+        return null;
+    }
+
+    private static class PrimitiveFieldWriter implements Consumer<Object> {
+
+        private final RecordConsumer recordConsumer;
+        private final String parquetFieldName;
+        private final int idx;
+        private final BiConsumer<RecordConsumer, Object> writer;
+
+        protected PrimitiveFieldWriter(RecordConsumer recordConsumer, String parquetFieldName, int idx,
+                BiConsumer<RecordConsumer, Object> writer) {
+            this.recordConsumer = recordConsumer;
+            this.parquetFieldName = parquetFieldName;
+            this.idx = idx;
+            this.writer = writer;
+        }
+
+        @Override
+        public void accept(Object object) {
+            recordConsumer.startField(parquetFieldName, idx);
+            writer.accept(recordConsumer, object);
+            recordConsumer.endField(parquetFieldName, idx);
+        }
+
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteModelField.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteModelField.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import java.util.function.Function;
+
+record WriteModelField(String parquetFieldName, int idx, Function<Object, Object> accessor) implements RecordField {
+
+    @Override
+    public Function<Object, Object> getAccessor() {
+        return accessor;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.apache.parquet.schema.Types.primitive;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.parquet.schema.ConversionPatterns;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.parquet.schema.Types;
+
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.model.CollectionType;
+import com.jerolba.carpet.model.FieldType;
+import com.jerolba.carpet.model.MapType;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+class WriteRecordModel2Schema {
+
+    private final CarpetWriteConfiguration carpetConfiguration;
+
+    public WriteRecordModel2Schema(CarpetWriteConfiguration carpetConfiguration) {
+        this.carpetConfiguration = carpetConfiguration;
+    }
+
+    public MessageType createSchema(WriteRecordModelType<?> writeRecordModelType) {
+        HashSet<WriteRecordModelType<?>> visited = new HashSet<>();
+        validateNotVisitedRecord(writeRecordModelType, visited);
+
+        String groupName = writeRecordModelType.getClassType().getSimpleName();
+        List<Type> fields = createGroupFields(writeRecordModelType, visited);
+        return new MessageType(groupName, fields);
+    }
+
+    private List<Type> createGroupFields(WriteRecordModelType<?> writeRecordModelType,
+            Set<WriteRecordModelType<?>> visited) {
+
+        List<Type> fields = new ArrayList<>();
+        for (var recordField : writeRecordModelType.getFields()) {
+            Repetition repetition = recordField.fieldType().isNotNull() ? REQUIRED : OPTIONAL;
+
+            Type type = createType(recordField.fieldType(), recordField.parquetFieldName(), repetition, visited);
+            if (type != null) {
+                fields.add(type);
+            } else {
+                throw new RecordTypeConversionException(
+                        "Column '" + recordField.parquetFieldName() + "' of type " +
+                                recordField.fieldType().getClass().getName() + " not supported");
+            }
+        }
+        return fields;
+    }
+
+    private Type createType(FieldType fieldtype, String parquetFieldName, Repetition repetition,
+            Set<WriteRecordModelType<?>> visited) {
+        if (fieldtype instanceof CollectionType collectionType) {
+            return createCollectionType(parquetFieldName, collectionType.type(), repetition, visited);
+        } else if (fieldtype instanceof MapType mapType) {
+            return createMapType(parquetFieldName, mapType, repetition, visited);
+        }
+        return buildIfNonCollectionParquetType(fieldtype, parquetFieldName, repetition, visited);
+    }
+
+    private Type createCollectionType(String parquetFieldName, FieldType collectionType,
+            Repetition repetition, Set<WriteRecordModelType<?>> visited) {
+        return switch (carpetConfiguration.annotatedLevels()) {
+        case ONE -> createCollectionOneLevel(parquetFieldName, collectionType, visited);
+        case TWO -> createCollectionTwoLevel(parquetFieldName, collectionType, repetition, visited);
+        case THREE -> createCollectionThreeLevel(parquetFieldName, collectionType, repetition, visited);
+        };
+    }
+
+    private Type createCollectionOneLevel(String parquetFieldName, FieldType parametized,
+            Set<WriteRecordModelType<?>> visited) {
+
+        if (parametized instanceof CollectionType) {
+            throw new RecordTypeConversionException(
+                    "Recursive collections not supported in annotated 1-level structures");
+        }
+        if (parametized instanceof MapType mapType) {
+            return createMapType(parquetFieldName, mapType, REPEATED, visited);
+        }
+        return buildTypeElement(parametized, parquetFieldName, REPEATED, visited);
+    }
+
+    private Type createCollectionTwoLevel(String parquetFieldName, FieldType parametized,
+            Repetition repetition, Set<WriteRecordModelType<?>> visited) {
+        // Two level collections elements are not nullables
+        Type nested = createNestedCollection(parametized, REPEATED, visited);
+        return ConversionPatterns.listType(repetition, parquetFieldName, nested);
+    }
+
+    private Type createCollectionThreeLevel(String parquetFieldName, FieldType parametized,
+            Repetition repetition, Set<WriteRecordModelType<?>> visited) {
+        // Three level collections elements are nullables
+        Type nested = createNestedCollection(parametized, OPTIONAL, visited);
+        return ConversionPatterns.listOfElements(repetition, parquetFieldName, nested);
+    }
+
+    private Type createNestedCollection(FieldType parametized, Repetition repetition,
+            Set<WriteRecordModelType<?>> visited) {
+        if (parametized instanceof CollectionType collectionType) {
+            return createCollectionType("element", collectionType.type(), repetition, visited);
+        }
+        if (parametized instanceof MapType mapType) {
+            return createMapType("element", mapType, repetition, visited);
+        }
+        return buildTypeElement(parametized, "element", repetition, visited);
+    }
+
+    private Type createMapType(String parquetFieldName, MapType mapType, Repetition repetition,
+            Set<WriteRecordModelType<?>> visited) {
+        FieldType keyType = mapType.keyType();
+        Type nestedKey = buildTypeElement(keyType, "key", REQUIRED, visited);
+
+        FieldType valueType = mapType.valueType();
+        if (valueType instanceof CollectionType collectionType) {
+            Type childCollection = createCollectionType("value", collectionType.type(), OPTIONAL, visited);
+            return Types.map(repetition).key(nestedKey).value(childCollection).named(parquetFieldName);
+        }
+        if (valueType instanceof MapType innerMapType) {
+            Type childMap = createMapType("value", innerMapType, OPTIONAL, visited);
+            return Types.map(repetition).key(nestedKey).value(childMap).named(parquetFieldName);
+        }
+
+        Type nestedValue = buildTypeElement(valueType, "value", OPTIONAL, visited);
+        if (nestedKey != null && nestedValue != null) {
+            // TODO: what to change to support generation of older versions?
+            return Types.map(repetition).key(nestedKey).value(nestedValue).named(parquetFieldName);
+        }
+        throw new RecordTypeConversionException("Unsuported type in Map");
+    }
+
+    private Type buildTypeElement(FieldType type, String name, Repetition repetition,
+            Set<WriteRecordModelType<?>> visited) {
+        Type parquetType = buildIfNonCollectionParquetType(type, name, repetition, visited);
+        if (parquetType == null) {
+            throw new RecordTypeConversionException("Unsuported type " + type);
+        }
+        return parquetType;
+    }
+
+    private Type buildIfNonCollectionParquetType(FieldType type, String parquetFieldName, Repetition repetition,
+            Set<WriteRecordModelType<?>> visited) {
+
+        FieldTypeInspect javaType = new FieldTypeInspect(type);
+        PrimitiveType primitiveType = buildIfPrimitiveType(javaType, repetition, parquetFieldName);
+        if (primitiveType != null) {
+            return primitiveType;
+        }
+        if (javaType.isString()) {
+            return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
+        }
+        if (javaType.isEnum()) {
+            return primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);
+        }
+        if (javaType.isUuid()) {
+            return primitive(FIXED_LEN_BYTE_ARRAY, repetition).as(uuidType())
+                    .length(UUIDLogicalTypeAnnotation.BYTES).named(parquetFieldName);
+        }
+        if (javaType.isBigDecimal()) {
+            return buildDecimalTypeItem(repetition, parquetFieldName);
+        }
+        PrimitiveType dateTypeItems = buildIfDateType(javaType, repetition, parquetFieldName);
+        if (dateTypeItems != null) {
+            return dateTypeItems;
+        }
+        if (type instanceof WriteRecordModelType<?> childWriteRecordType) {
+            List<Type> childFields = buildChildFields(childWriteRecordType, visited);
+            return new GroupType(repetition, parquetFieldName, childFields);
+        }
+        return null;
+    }
+
+    private List<Type> buildChildFields(WriteRecordModelType<?> writeRecordType, Set<WriteRecordModelType<?>> visited) {
+        validateNotVisitedRecord(writeRecordType, visited);
+        List<Type> fields = createGroupFields(writeRecordType, visited);
+        visited.remove(writeRecordType);
+        return fields;
+    }
+
+    private PrimitiveType buildIfPrimitiveType(FieldTypeInspect javaType, Repetition repetition, String name) {
+        if (javaType.isInteger()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).named(name);
+        }
+        if (javaType.isLong()) {
+            return primitive(PrimitiveTypeName.INT64, repetition).named(name);
+        }
+        if (javaType.isFloat()) {
+            return primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+        }
+        if (javaType.isDouble()) {
+            return primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+        }
+        if (javaType.isBoolean()) {
+            return primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+        }
+        if (javaType.isShort()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(16, true)).named(name);
+        }
+        if (javaType.isByte()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(8, true)).named(name);
+        }
+        return null;
+    }
+
+    private PrimitiveType buildIfDateType(FieldTypeInspect javaType, Repetition repetition, String name) {
+        if (javaType.isLocalDate()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(dateType()).named(name);
+        }
+        if (javaType.isLocalTime()) {
+            TimeUnit timeUnit = carpetConfiguration.defaultTimeUnit();
+            boolean isAdjustedToUTC = carpetConfiguration.defaultTimeIsAdjustedToUTC();
+            LogicalTypeAnnotation timeType = timeType(isAdjustedToUTC, toParquetTimeUnit(timeUnit));
+            var typeName = switch (timeUnit) {
+            case MILLIS -> PrimitiveTypeName.INT32;
+            case MICROS, NANOS -> PrimitiveTypeName.INT64;
+            };
+            return primitive(typeName, repetition).as(timeType).named(name);
+        }
+        if (javaType.isLocalDateTime()) {
+            TimeUnit timeUnit = carpetConfiguration.defaultTimeUnit();
+            var timeStampType = timestampType(false, toParquetTimeUnit(timeUnit));
+            return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
+        }
+        if (javaType.isInstant()) {
+            TimeUnit timeUnit = carpetConfiguration.defaultTimeUnit();
+            var timeStampType = timestampType(true, toParquetTimeUnit(timeUnit));
+            return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
+        }
+        return null;
+    }
+
+    private LogicalTypeAnnotation.TimeUnit toParquetTimeUnit(TimeUnit timeUnit) {
+        return switch (timeUnit) {
+        case MILLIS -> LogicalTypeAnnotation.TimeUnit.MILLIS;
+        case MICROS -> LogicalTypeAnnotation.TimeUnit.MICROS;
+        case NANOS -> LogicalTypeAnnotation.TimeUnit.NANOS;
+        };
+    }
+
+    private Type buildDecimalTypeItem(Repetition repetition, String name) {
+        DecimalConfig decimalConfig = carpetConfiguration.decimalConfig();
+        if (decimalConfig == null) {
+            throw new RecordTypeConversionException("If BigDecimall is used, a Default Decimal configuration "
+                    + "must be provided in the setup of CarpetWriter builder");
+        }
+        var decimalType = decimalType(decimalConfig.scale(), decimalConfig.precision());
+        if (decimalConfig.precision() <= 9) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(decimalType).named(name);
+        }
+        if (decimalConfig.precision() <= 18) {
+            return primitive(PrimitiveTypeName.INT64, repetition).as(decimalType).named(name);
+        }
+        return primitive(PrimitiveTypeName.BINARY, repetition).as(decimalType).named(name);
+    }
+
+    private void validateNotVisitedRecord(WriteRecordModelType<?> recordClass, Set<WriteRecordModelType<?>> visited) {
+        if (visited.contains(recordClass)) {
+            throw new RecordTypeConversionException("Recusive records are not supported");
+        }
+        visited.add(recordClass);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModelWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModelWriter.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static com.jerolba.carpet.impl.write.CollectionsWriters.MapRecordFieldWriter.writeKeyalueGroup;
+import static com.jerolba.carpet.impl.write.CollectionsWriters.ThreeLevelCollectionRecordFieldWriter.writeGroupElementThree;
+import static com.jerolba.carpet.impl.write.CollectionsWriters.TwoLevelCollectionRecordFieldWriter.writeGroupElementTwo;
+import static com.jerolba.carpet.impl.write.ModelFieldsWriter.buildPrimitiveJavaConsumer;
+import static com.jerolba.carpet.impl.write.ModelFieldsWriter.buildSimpleElementConsumer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.parquet.io.api.RecordConsumer;
+
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.impl.write.CollectionsWriters.OneLevelCollectionFieldWriter;
+import com.jerolba.carpet.impl.write.CollectionsWriters.ThreeLevelCollectionRecordFieldWriter;
+import com.jerolba.carpet.impl.write.CollectionsWriters.TwoLevelCollectionRecordFieldWriter;
+import com.jerolba.carpet.model.CollectionType;
+import com.jerolba.carpet.model.FieldType;
+import com.jerolba.carpet.model.MapType;
+import com.jerolba.carpet.model.WriteField;
+import com.jerolba.carpet.model.WriteRecordModelType;
+import com.jerolba.carpet.model.WriteRecordModelType.FunctionFieldInfo;
+import com.jerolba.carpet.model.WriteRecordModelType.PrimitiveJavaFieldInfo;
+
+class WriteRecordModelWriter {
+
+    private final RecordConsumer recordConsumer;
+    private final CarpetWriteConfiguration carpetConfiguration;
+
+    private final List<Consumer<Object>> fieldWriters = new ArrayList<>();
+
+    public WriteRecordModelWriter(RecordConsumer recordConsumer, WriteRecordModelType<?> writeRecordModelType,
+            CarpetWriteConfiguration carpetConfiguration) {
+        this.recordConsumer = recordConsumer;
+        this.carpetConfiguration = carpetConfiguration;
+
+        int idx = 0;
+        for (WriteField<?> field : writeRecordModelType.getFields()) {
+            Consumer<Object> writer = buildFieldWriter(recordConsumer, idx, field);
+            if (writer == null) {
+                throw new RuntimeException(field.fieldType().getClass().getName() + " can not be serialized");
+            }
+            fieldWriters.add(writer);
+            idx++;
+        }
+    }
+
+    public void write(Object record) {
+        for (var fieldWriter : fieldWriters) {
+            fieldWriter.accept(record);
+        }
+    }
+
+    private Consumer<Object> buildFieldWriter(RecordConsumer recordConsumer, int idx, WriteField<?> field) {
+        if (field instanceof PrimitiveJavaFieldInfo<?> primitiveJavaField) {
+            return buildPrimitiveJavaConsumer(primitiveJavaField, idx, recordConsumer);
+        }
+        if (field instanceof FunctionFieldInfo<?> functionField) {
+            Function<Object, Object> accessor = (Function<Object, Object>) functionField.accessor();
+            RecordField modelField = new WriteModelField(field.parquetFieldName(), idx, accessor);
+            FieldType type = field.fieldType();
+            if (type instanceof CollectionType collectionType) {
+                return createCollectionWriter(collectionType, modelField);
+            } else if (type instanceof MapType mapType) {
+                return createMapStructureWriter(mapType, modelField);
+            }
+            BiConsumer<RecordConsumer, Object> basicTypeWriter = buildSimpleElementConsumer(type, recordConsumer,
+                    carpetConfiguration);
+            if (basicTypeWriter != null) {
+                return new FieldWriterConsumer(recordConsumer, modelField, basicTypeWriter);
+            }
+        }
+        return null;
+    }
+
+    private Consumer<Object> createCollectionWriter(CollectionType collectionType, RecordField recordField) {
+        return switch (carpetConfiguration.annotatedLevels()) {
+        case ONE -> createOneLevelStructureWriter(collectionType.type(), recordField);
+        case TWO -> createTwoLevelStructureWriter(collectionType.type(), recordField);
+        case THREE -> createThreeLevelStructureWriter(collectionType.type(), recordField);
+        };
+    }
+
+    private Consumer<Object> createOneLevelStructureWriter(FieldType parametized, RecordField recordField) {
+        if (parametized instanceof CollectionType) {
+            throw new RecordTypeConversionException(
+                    "Nested collection in a collection is not supported in single level structure codification");
+        }
+        BiConsumer<RecordConsumer, Object> elemConsumer = null;
+        if (parametized instanceof MapType mapType) {
+            Consumer<Object> childWriter = createMapStructureWriter(mapType, null);
+            elemConsumer = (consumer, v) -> childWriter.accept(v);
+        } else {
+            elemConsumer = buildSimpleElementConsumer(parametized, recordConsumer, carpetConfiguration);
+        }
+        if (elemConsumer == null) {
+            throw new RecordTypeConversionException("Unsuported type in collection");
+        }
+        return new OneLevelCollectionFieldWriter(recordConsumer, recordField, elemConsumer);
+    }
+
+    private Consumer<Object> createTwoLevelStructureWriter(FieldType parametized, RecordField recordField) {
+        BiConsumer<RecordConsumer, Object> elemConsumer = null;
+        if (parametized instanceof CollectionType collectionType) {
+            Consumer<Object> childWriter = createTwoLevelStructureWriter(collectionType.type(), null);
+            elemConsumer = (consumer, v) -> childWriter.accept(v);
+        } else if (parametized instanceof MapType mapType) {
+            Consumer<Object> childWriter = createMapStructureWriter(mapType, null);
+            elemConsumer = (consumer, v) -> childWriter.accept(v);
+        } else {
+            elemConsumer = buildSimpleElementConsumer(parametized, recordConsumer, carpetConfiguration);
+        }
+        if (elemConsumer == null) {
+            throw new RecordTypeConversionException("Unsuported type in collection");
+        }
+        if (recordField != null) {
+            return new TwoLevelCollectionRecordFieldWriter(recordConsumer, recordField, elemConsumer);
+        }
+        // We are referenced by other collection
+        var innerStructureWriter = elemConsumer;
+        return value -> {
+            Collection<?> coll = (Collection<?>) value;
+            if (coll != null) {
+                writeGroupElementTwo(recordConsumer, innerStructureWriter, coll);
+            }
+        };
+    }
+
+    private Consumer<Object> createThreeLevelStructureWriter(FieldType parametized, RecordField recordField) {
+        BiConsumer<RecordConsumer, Object> elemConsumer = null;
+        if (parametized instanceof CollectionType collectionType) {
+            Consumer<Object> childWriter = createThreeLevelStructureWriter(collectionType.type(), null);
+            elemConsumer = (consumer, v) -> childWriter.accept(v);
+        } else if (parametized instanceof MapType mapType) {
+            Consumer<Object> childWriter = createMapStructureWriter(mapType, null);
+            elemConsumer = (consumer, v) -> childWriter.accept(v);
+        } else {
+            elemConsumer = buildSimpleElementConsumer(parametized, recordConsumer, carpetConfiguration);
+        }
+        if (elemConsumer == null) {
+            throw new RecordTypeConversionException("Unsuported type in collection");
+        }
+        if (recordField != null) {
+            return new ThreeLevelCollectionRecordFieldWriter(recordConsumer, recordField, elemConsumer);
+        }
+        // We are referenced by other collection
+        var innerStructureWriter = elemConsumer;
+        return value -> {
+            Collection<?> coll = (Collection<?>) value;
+            if (coll != null) {
+                recordConsumer.startGroup();
+                if (!coll.isEmpty()) {
+                    writeGroupElementThree(recordConsumer, innerStructureWriter, coll);
+                }
+                recordConsumer.endGroup();
+            }
+        };
+    }
+
+    private Consumer<Object> createMapStructureWriter(MapType mapType, RecordField recordField) {
+        // Key
+        BiConsumer<RecordConsumer, Object> elemKeyConsumer = null;
+        FieldType keyType = mapType.keyType();
+        elemKeyConsumer = buildSimpleElementConsumer(keyType, recordConsumer, carpetConfiguration);
+
+        // Value
+        BiConsumer<RecordConsumer, Object> elemValueConsumer = null;
+        if (mapType.valueType() instanceof CollectionType valueCollectionType) {
+            Consumer<Object> childWriter = createCollectionWriter(valueCollectionType, null);
+            elemValueConsumer = (consumer, v) -> childWriter.accept(v);
+        } else if (mapType.valueType() instanceof MapType valueMapType) {
+            Consumer<Object> childWriter = createMapStructureWriter(valueMapType, null);
+            elemValueConsumer = (consumer, v) -> childWriter.accept(v);
+        } else {
+            elemValueConsumer = buildSimpleElementConsumer(mapType.valueType(), recordConsumer, carpetConfiguration);
+        }
+        if (elemValueConsumer == null || elemKeyConsumer == null) {
+            throw new RecordTypeConversionException("Unsuported type in Map");
+        }
+        if (recordField != null) {
+            return new CollectionsWriters.MapRecordFieldWriter(recordConsumer, recordField, elemKeyConsumer,
+                    elemValueConsumer);
+        }
+        // We are referenced by other collection
+        var innerKeyStructureWriter = elemKeyConsumer;
+        var innerValueStructureWriter = elemValueConsumer;
+        return value -> {
+            if (value != null) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                recordConsumer.startGroup();
+                if (!map.isEmpty()) {
+                    writeKeyalueGroup(recordConsumer, innerKeyStructureWriter, innerValueStructureWriter, map);
+                }
+                recordConsumer.endGroup();
+            }
+        };
+    }
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteSupportFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteSupportFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import java.util.Map;
+
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.hadoop.api.WriteSupport;
+
+import com.jerolba.carpet.WriteModelFactory;
+import com.jerolba.carpet.WriteModelFactory.WriteConfigurationContext;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+public class WriteSupportFactory {
+
+    private WriteSupportFactory() {
+    }
+
+    public static <T> WriteSupport<T> createWriteSupport(Class<T> recordClass, Map<String, String> extraMetaData,
+            ParquetConfiguration parquetConfiguration, CarpetWriteConfiguration carpetConfiguration,
+            WriteModelFactory<T> writeModelFactory) {
+
+        if (writeModelFactory == null) {
+            if (parquetConfiguration.getBoolean("parquet.carpet.useJavaRecord2WriteModel", false)) {
+                JavaRecord2WriteModel javaRecord2WriteModel = new JavaRecord2WriteModel(carpetConfiguration);
+                WriteRecordModelType<T> rootWriteRecordModel = javaRecord2WriteModel.createModel(recordClass);
+                return new WriteRecordModelWriteSupport<>(rootWriteRecordModel, extraMetaData, carpetConfiguration);
+            }
+            return new CarpetWriteSupport<>(recordClass, extraMetaData, carpetConfiguration);
+        }
+        var writeConfigurationContext = new WriteConfigurationContext(carpetConfiguration, parquetConfiguration);
+        WriteRecordModelType<T> rootWriteRecordModel = writeModelFactory.create(recordClass, writeConfigurationContext);
+        return new WriteRecordModelWriteSupport<>(rootWriteRecordModel, extraMetaData, carpetConfiguration);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BigDecimalType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BigDecimalType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.math.BigDecimal;
+
+public record BigDecimalType(boolean isNotNull) implements FieldType {
+
+    public BigDecimalType notNull() {
+        return new BigDecimalType(true);
+    }
+
+    @Override
+    public Class<BigDecimal> getClassType() {
+        return BigDecimal.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BooleanType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BooleanType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record BooleanType(boolean isNotNull) implements FieldType {
+
+    public BooleanType notNull() {
+        return new BooleanType(true);
+    }
+
+    @Override
+    public Class<Boolean> getClassType() {
+        return Boolean.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ByteType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ByteType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record ByteType(boolean isNotNull) implements FieldType {
+
+    public ByteType notNull() {
+        return new ByteType(true);
+    }
+
+    @Override
+    public Class<Byte> getClassType() {
+        return Byte.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/CollectionType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/CollectionType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public sealed interface CollectionType extends FieldType permits ListType, SetType {
+
+    FieldType type();
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/DoubleType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/DoubleType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record DoubleType(boolean isNotNull) implements FieldType {
+
+    public DoubleType notNull() {
+        return new DoubleType(true);
+    }
+
+    @Override
+    public Class<Double> getClassType() {
+        return Double.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass) implements FieldType {
+
+    public EnumType notNull() {
+        return new EnumType(true, enumClass);
+    }
+
+    @Override
+    public Class<? extends Enum<?>> getClassType() {
+        return enumClass;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public class EnumTypeBuilder {
+
+    private final boolean notNull;
+
+    EnumTypeBuilder() {
+        this(false);
+    }
+
+    private EnumTypeBuilder(boolean notNull) {
+        this.notNull = notNull;
+    }
+
+    public EnumTypeBuilder notNull() {
+        return new EnumTypeBuilder(true);
+    }
+
+    public EnumType ofType(Class<? extends Enum<?>> enumClass) {
+        return new EnumType(notNull, enumClass);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FieldType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FieldType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public sealed interface FieldType
+        permits BooleanType, ByteType, ShortType, IntegerType,
+        LongType, FloatType, DoubleType, StringType, EnumType,
+        UuidType, BigDecimalType, LocalDateType, LocalTimeType,
+        LocalDateTimeType, InstantType, CollectionType, ListType,
+        SetType, MapType, WriteRecordModelType {
+
+    boolean isNotNull();
+
+    Class<?> getClassType();
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public class FieldTypes {
+
+    public static final BooleanType BOOLEAN = new BooleanType(false);
+    public static final ByteType BYTE = new ByteType(false);
+    public static final ShortType SHORT = new ShortType(false);
+    public static final IntegerType INTEGER = new IntegerType(false);
+    public static final LongType LONG = new LongType(false);
+    public static final FloatType FLOAT = new FloatType(false);
+    public static final DoubleType DOUBLE = new DoubleType(false);
+    public static final StringType STRING = new StringType(false);
+    public static final EnumTypeBuilder ENUM = new EnumTypeBuilder();
+    public static final UuidType UUID = new UuidType(false);
+    public static final BigDecimalType BIG_DECIMAL = new BigDecimalType(false);
+    public static final LocalDateType LOCAL_DATE = new LocalDateType(false);
+    public static final LocalTimeType LOCAL_TIME = new LocalTimeType(false);
+    public static final LocalDateTimeType LOCAL_DATE_TIME = new LocalDateTimeType(false);
+    public static final InstantType INSTANT = new InstantType(false);
+    public static final ListTypeBuilder LIST = new ListTypeBuilder();
+    public static final SetTypeBuilder SET = new SetTypeBuilder();
+    public static final MapTypeBuilder MAP = new MapTypeBuilder();
+
+    public static <T> WriteRecordModelType<T> writeRecordModel(Class<T> entityClass) {
+        return WriteRecordModelType.writeRecordModel(entityClass);
+    }
+
+    private FieldTypes() {
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FloatType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FloatType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record FloatType(boolean isNotNull) implements FieldType {
+
+    public FloatType notNull() {
+        return new FloatType(true);
+    }
+
+    @Override
+    public Class<Float> getClassType() {
+        return Float.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/InstantType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/InstantType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.time.Instant;
+
+public record InstantType(boolean isNotNull) implements FieldType {
+
+    public InstantType notNull() {
+        return new InstantType(true);
+    }
+
+    @Override
+    public Class<Instant> getClassType() {
+        return Instant.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/IntegerType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/IntegerType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record IntegerType(boolean isNotNull) implements FieldType {
+
+    public IntegerType notNull() {
+        return new IntegerType(true);
+    }
+
+    @Override
+    public Class<Integer> getClassType() {
+        return Integer.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ListType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ListType.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.util.Collection;
+
+public record ListType(boolean isNotNull, FieldType type) implements FieldType, CollectionType {
+
+    public ListType {
+        if (type == null) {
+            throw new IllegalArgumentException("List type can not be null");
+        }
+    }
+
+    public ListType notNull() {
+        return new ListType(true, type);
+    }
+
+    @Override
+    public Class<Collection> getClassType() {
+        return Collection.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ListTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ListTypeBuilder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public class ListTypeBuilder {
+
+    private final boolean notNull;
+
+    ListTypeBuilder() {
+        this(false);
+    }
+
+    private ListTypeBuilder(boolean notNull) {
+        this.notNull = notNull;
+    }
+
+    public ListTypeBuilder notNull() {
+        return new ListTypeBuilder(true);
+    }
+
+    public ListType ofType(FieldType type) {
+        return new ListType(notNull, type);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/LocalDateTimeType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/LocalDateTimeType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.time.LocalDateTime;
+
+public record LocalDateTimeType(boolean isNotNull) implements FieldType {
+
+    public LocalDateTimeType notNull() {
+        return new LocalDateTimeType(true);
+    }
+
+    @Override
+    public Class<LocalDateTime> getClassType() {
+        return LocalDateTime.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/LocalDateType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/LocalDateType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.time.LocalDate;
+
+public record LocalDateType(boolean isNotNull) implements FieldType {
+
+    public LocalDateType notNull() {
+        return new LocalDateType(true);
+    }
+
+    @Override
+    public Class<LocalDate> getClassType() {
+        return LocalDate.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/LocalTimeType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/LocalTimeType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.time.LocalTime;
+
+public record LocalTimeType(boolean isNotNull) implements FieldType {
+
+    public LocalTimeType notNull() {
+        return new LocalTimeType(true);
+    }
+
+    @Override
+    public Class<LocalTime> getClassType() {
+        return LocalTime.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/LongType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/LongType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record LongType(boolean isNotNull) implements FieldType {
+
+    public LongType notNull() {
+        return new LongType(true);
+    }
+
+    @Override
+    public Class<Long> getClassType() {
+        return Long.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/MapType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/MapType.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.util.Map;
+
+public record MapType(boolean isNotNull, FieldType keyType, FieldType valueType) implements FieldType {
+
+    public MapType {
+        if (keyType == null) {
+            throw new IllegalArgumentException("Map key type can not be null");
+        }
+        if (valueType == null) {
+            throw new IllegalArgumentException("Map value type can not be null");
+        }
+    }
+
+    public MapType notNull() {
+        return new MapType(true, keyType, valueType);
+    }
+
+    @Override
+    public Class<Map> getClassType() {
+        return Map.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/MapTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/MapTypeBuilder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public class MapTypeBuilder {
+
+    private final boolean notNull;
+
+    MapTypeBuilder() {
+        this(false);
+    }
+
+    private MapTypeBuilder(boolean notNull) {
+        this.notNull = notNull;
+    }
+
+    public MapTypeBuilder notNull() {
+        return new MapTypeBuilder(true);
+    }
+
+    public MapType ofTypes(FieldType keyType, FieldType valueType) {
+        return new MapType(notNull, keyType, valueType);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/SetType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/SetType.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.util.Collection;
+
+public record SetType(boolean isNotNull, FieldType type) implements FieldType, CollectionType {
+
+    public SetType {
+        if (type == null) {
+            throw new IllegalArgumentException("Set type can not be null");
+        }
+    }
+
+    public SetType notNull() {
+        return new SetType(true, type);
+    }
+
+    @Override
+    public Class<Collection> getClassType() {
+        return Collection.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/SetTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/SetTypeBuilder.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public class SetTypeBuilder {
+
+    private final boolean notNull;
+
+    SetTypeBuilder() {
+        this(false);
+    }
+
+    private SetTypeBuilder(boolean notNull) {
+        this.notNull = notNull;
+    }
+
+    public SetTypeBuilder notNull() {
+        return new SetTypeBuilder(true);
+    }
+
+    public SetType ofType(FieldType type) {
+        return new SetType(notNull, type);
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ShortType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ShortType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record ShortType(boolean isNotNull) implements FieldType {
+
+    public ShortType notNull() {
+        return new ShortType(true);
+    }
+
+    @Override
+    public Class<Short> getClassType() {
+        return Short.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/StringType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/StringType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public record StringType(boolean isNotNull) implements FieldType {
+
+    public StringType notNull() {
+        return new StringType(true);
+    }
+
+    @Override
+    public Class<String> getClassType() {
+        return String.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ToBooleanFunction.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ToBooleanFunction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+@FunctionalInterface
+public interface ToBooleanFunction<T> {
+
+    boolean applyAsBoolean(T value);
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ToByteFunction.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ToByteFunction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+@FunctionalInterface
+public interface ToByteFunction<T> {
+
+    byte applyAsByte(T value);
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ToFloatFunction.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ToFloatFunction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+@FunctionalInterface
+public interface ToFloatFunction<T> {
+
+    float applyAsFloat(T value);
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/ToShortFunction.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/ToShortFunction.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+@FunctionalInterface
+public interface ToShortFunction<T> {
+
+    short applyAsShort(T value);
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/UuidType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/UuidType.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import java.util.UUID;
+
+public record UuidType(boolean isNotNull) implements FieldType {
+
+    public UuidType notNull() {
+        return new UuidType(true);
+    }
+
+    @Override
+    public Class<UUID> getClassType() {
+        return UUID.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/WriteField.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/WriteField.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public interface WriteField<T> {
+
+    String parquetFieldName();
+
+    FieldType fieldType();
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/WriteRecordModelType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/WriteRecordModelType.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.BYTE;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.FLOAT;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LONG;
+import static com.jerolba.carpet.model.FieldTypes.SHORT;
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+
+public final class WriteRecordModelType<T> implements FieldType {
+
+    private final Class<T> recordClass;
+    private final List<WriteField<T>> fields = new ArrayList<>();
+    private final Map<String, WriteField<T>> indexedFields = new HashMap<>();
+    private boolean isNotNull = false;
+
+    WriteRecordModelType(Class<T> recordClass) {
+        this.recordClass = recordClass;
+    }
+
+    static <T> WriteRecordModelType<T> writeRecordModel(Class<T> recordClass) {
+        return new WriteRecordModelType<>(recordClass);
+    }
+
+    @Override
+    public Class<T> getClassType() {
+        return recordClass;
+    }
+
+    public WriteRecordModelType<T> notNull() {
+        isNotNull = true;
+        return this;
+    }
+
+    @Override
+    public boolean isNotNull() {
+        return isNotNull;
+    }
+
+    public List<WriteField<T>> getFields() {
+        return fields;
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, FieldType type, Function<T, Object> accessor) {
+        requireNonNull(parquetFieldName);
+        requireNonNull(type);
+        requireNonNull(accessor);
+        if (indexedFields.containsKey(parquetFieldName)) {
+            throw new IllegalArgumentException(parquetFieldName + " already defined");
+        }
+        var field = new FunctionFieldInfo<>(parquetFieldName, type, accessor);
+        fields.add(field);
+        indexedFields.put(parquetFieldName, field);
+        return this;
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToBooleanFunction<T> accessor) {
+        return primitiveField(parquetFieldName, BOOLEAN.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToByteFunction<T> accessor) {
+        return primitiveField(parquetFieldName, BYTE.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToShortFunction<T> accessor) {
+        return primitiveField(parquetFieldName, SHORT.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToIntFunction<T> accessor) {
+        return primitiveField(parquetFieldName, INTEGER.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToLongFunction<T> accessor) {
+        return primitiveField(parquetFieldName, LONG.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToFloatFunction<T> accessor) {
+        return primitiveField(parquetFieldName, FLOAT.notNull(), accessor);
+    }
+
+    public WriteRecordModelType<T> withField(String parquetFieldName, ToDoubleFunction<T> accessor) {
+        return primitiveField(parquetFieldName, DOUBLE.notNull(), accessor);
+    }
+
+    private WriteRecordModelType<T> primitiveField(String parquetFieldName, FieldType type, Object accessor) {
+        requireNonNull(parquetFieldName);
+        requireNonNull(accessor);
+        if (indexedFields.containsKey(parquetFieldName)) {
+            throw new IllegalArgumentException(parquetFieldName + " already defined");
+        }
+        if (!type.isNotNull()) {
+            throw new IllegalArgumentException(parquetFieldName + " is not defined as not null");
+        }
+        WriteField<T> field = new PrimitiveJavaFieldInfo<>(parquetFieldName, type, accessor);
+        fields.add(field);
+        indexedFields.put(parquetFieldName, field);
+        return this;
+    }
+
+    public record PrimitiveJavaFieldInfo<T>(String parquetFieldName, FieldType fieldType, Object accessor)
+            implements WriteField<T> {
+    }
+
+    public record FunctionFieldInfo<T>(String parquetFieldName, FieldType fieldType, Function<T, Object> accessor)
+            implements WriteField<T> {
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -1,0 +1,1869 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static com.jerolba.carpet.TimeUnit.MICROS;
+import static com.jerolba.carpet.TimeUnit.MILLIS;
+import static com.jerolba.carpet.TimeUnit.NANOS;
+import static com.jerolba.carpet.impl.write.DecimalConfig.decimalConfig;
+import static com.jerolba.carpet.model.FieldTypes.BIG_DECIMAL;
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.BYTE;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.ENUM;
+import static com.jerolba.carpet.model.FieldTypes.FLOAT;
+import static com.jerolba.carpet.model.FieldTypes.INSTANT;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_DATE;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_DATE_TIME;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_TIME;
+import static com.jerolba.carpet.model.FieldTypes.LONG;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.SHORT;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.UUID;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.parquet.schema.MessageType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.AnnotatedLevels;
+import com.jerolba.carpet.ColumnNamingStrategy;
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+class WriteRecord2SchemaTest {
+
+    @Test
+    void simpleRecordTest() {
+        record SimpleRecord(long id, String name) {
+        }
+
+        var rootType = writeRecordModel(SimpleRecord.class)
+                .withField("id", LONG.notNull(), SimpleRecord::id)
+                .withField("name", STRING, SimpleRecord::name);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Test
+    void privitiveTypesRecordTest() {
+        record PrimitiveTypesRecord(long longValue, int intValue, float floatValue, double doubleValue,
+                short shortValue, byte byteValue, boolean booleanValue) {
+        }
+
+        var rootType = writeRecordModel(PrimitiveTypesRecord.class)
+                .withField("longValue", LONG.notNull(), PrimitiveTypesRecord::longValue)
+                .withField("intValue", INTEGER.notNull(), PrimitiveTypesRecord::intValue)
+                .withField("floatValue", FLOAT.notNull(), PrimitiveTypesRecord::floatValue)
+                .withField("doubleValue", DOUBLE.notNull(), PrimitiveTypesRecord::doubleValue)
+                .withField("shortValue", SHORT.notNull(), PrimitiveTypesRecord::shortValue)
+                .withField("byteValue", BYTE.notNull(), PrimitiveTypesRecord::byteValue)
+                .withField("booleanValue", BOOLEAN.notNull(), PrimitiveTypesRecord::booleanValue);
+
+        String expected = """
+                message PrimitiveTypesRecord {
+                  required int64 longValue;
+                  required int32 intValue;
+                  required float floatValue;
+                  required double doubleValue;
+                  required int32 shortValue (INTEGER(16,true));
+                  required int32 byteValue (INTEGER(8,true));
+                  required boolean booleanValue;
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Test
+    void privitiveObjectsTypesRecordTest() {
+        record PrimitiveObjectsTypesRecord(Long longValue, Integer intValue, Float floatValue, Double doubleValue,
+                Short shortValue, Byte byteValue, Boolean booleanValue) {
+        }
+
+        var rootType = writeRecordModel(PrimitiveObjectsTypesRecord.class)
+                .withField("longValue", LONG, PrimitiveObjectsTypesRecord::longValue)
+                .withField("intValue", INTEGER, PrimitiveObjectsTypesRecord::intValue)
+                .withField("floatValue", FLOAT, PrimitiveObjectsTypesRecord::floatValue)
+                .withField("doubleValue", DOUBLE, PrimitiveObjectsTypesRecord::doubleValue)
+                .withField("shortValue", SHORT, PrimitiveObjectsTypesRecord::shortValue)
+                .withField("byteValue", BYTE, PrimitiveObjectsTypesRecord::byteValue)
+                .withField("booleanValue", BOOLEAN, PrimitiveObjectsTypesRecord::booleanValue);
+
+        String expected = """
+                message PrimitiveObjectsTypesRecord {
+                  optional int64 longValue;
+                  optional int32 intValue;
+                  optional float floatValue;
+                  optional double doubleValue;
+                  optional int32 shortValue (INTEGER(16,true));
+                  optional int32 byteValue (INTEGER(8,true));
+                  optional boolean booleanValue;
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Test
+    void notNullFieldRecordTest() {
+        record NotNullFieldRecord(Long id, String name) {
+        }
+
+        var rootType = writeRecordModel(NotNullFieldRecord.class)
+                .withField("id", LONG.notNull(), NotNullFieldRecord::id)
+                .withField("name", STRING.notNull(), NotNullFieldRecord::name);
+
+        String expected = """
+                message NotNullFieldRecord {
+                  required int64 id;
+                  required binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Nested
+    class DecimalConfiguration {
+
+        @Test
+        void recordField() {
+            record RecordFieldDecimal(BigDecimal value) {
+            }
+
+            var rootType = writeRecordModel(RecordFieldDecimal.class)
+                    .withField("value", BIG_DECIMAL, RecordFieldDecimal::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(20, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message RecordFieldDecimal {
+                      optional binary value (DECIMAL(20,4));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void intPrecision() {
+            record RecordFieldDecimal(BigDecimal value) {
+            }
+
+            var rootType = writeRecordModel(RecordFieldDecimal.class)
+                    .withField("value", BIG_DECIMAL, RecordFieldDecimal::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(9, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message RecordFieldDecimal {
+                      optional int32 value (DECIMAL(9,4));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void longPrecision() {
+            record RecordFieldDecimal(BigDecimal value) {
+            }
+
+            var rootType = writeRecordModel(RecordFieldDecimal.class)
+                    .withField("value", BIG_DECIMAL, RecordFieldDecimal::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(18, 8))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message RecordFieldDecimal {
+                      optional int64 value (DECIMAL(18,8));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void collectionValue() {
+            record CollectionDecimalValue(List<BigDecimal> value) {
+            }
+
+            var rootType = writeRecordModel(CollectionDecimalValue.class)
+                    .withField("value", LIST.ofType(BIG_DECIMAL), CollectionDecimalValue::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(20, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message CollectionDecimalValue {
+                      optional group value (LIST) {
+                        repeated group list {
+                          optional binary element (DECIMAL(20,4));
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedCollectionValue() {
+            record NestedCollectionDecimalValue(List<List<BigDecimal>> value) {
+            }
+
+            var rootType = writeRecordModel(NestedCollectionDecimalValue.class)
+                    .withField("value", LIST.ofType(LIST.ofType(BIG_DECIMAL)),
+                            NestedCollectionDecimalValue::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(20, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NestedCollectionDecimalValue {
+                      optional group value (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional binary element (DECIMAL(20,4));
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void mapKeyAndValue() {
+            record MapKeyValueDecimals(Map<BigDecimal, BigDecimal> value) {
+            }
+
+            var rootType = writeRecordModel(MapKeyValueDecimals.class)
+                    .withField("value", MAP.ofTypes(BIG_DECIMAL, BIG_DECIMAL),
+                            MapKeyValueDecimals::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(20, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message MapKeyValueDecimals {
+                      optional group value (MAP) {
+                        repeated group key_value {
+                          required binary key (DECIMAL(20,4));
+                          optional binary value (DECIMAL(20,4));
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedMapKeyAndValue() {
+            record NestedMapKeyValueDecimal(Map<BigDecimal, Map<BigDecimal, BigDecimal>> value) {
+            }
+
+            var rootType = writeRecordModel(NestedMapKeyValueDecimal.class)
+                    .withField("value", MAP.ofTypes(BIG_DECIMAL, MAP.ofTypes(BIG_DECIMAL, BIG_DECIMAL)),
+                            NestedMapKeyValueDecimal::value);
+
+            CarpetWriteConfiguration config = config()
+                    .decimalConfig(decimalConfig().withPrecionAndScale(20, 4))
+                    .build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NestedMapKeyValueDecimal {
+                      optional group value (MAP) {
+                        repeated group key_value {
+                          required binary key (DECIMAL(20,4));
+                          optional group value (MAP) {
+                            repeated group key_value {
+                              required binary key (DECIMAL(20,4));
+                              optional binary value (DECIMAL(20,4));
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Test
+    void dateTypesRecordTest() {
+        record DateTypesRecord(LocalDate localDate, LocalTime localTime, Instant instant, LocalDateTime localDateTime) {
+        }
+
+        var rootType = writeRecordModel(DateTypesRecord.class)
+                .withField("localDate", LOCAL_DATE, DateTypesRecord::localDate)
+                .withField("localTime", LOCAL_TIME, DateTypesRecord::localTime)
+                .withField("instant", INSTANT, DateTypesRecord::instant)
+                .withField("localDateTime", LOCAL_DATE_TIME, DateTypesRecord::localDateTime);
+
+        String expected = """
+                message DateTypesRecord {
+                  optional int32 localDate (DATE);
+                  optional int32 localTime (TIME(MILLIS,true));
+                  optional int64 instant (TIMESTAMP(MILLIS,true));
+                  optional int64 localDateTime (TIMESTAMP(MILLIS,false));
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Nested
+    class TimeDefinition {
+
+        record TimeRecord(LocalTime localTime) {
+        }
+
+        @Test
+        void millis() {
+            var rootType = writeRecordModel(TimeRecord.class)
+                    .withField("localTime", LOCAL_TIME, TimeRecord::localTime);
+
+            CarpetWriteConfiguration config = config().timeUnit(MILLIS).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message TimeRecord {
+                      optional int32 localTime (TIME(MILLIS,true));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void micros() {
+            var rootType = writeRecordModel(TimeRecord.class)
+                    .withField("localTime", LOCAL_TIME, TimeRecord::localTime);
+
+            CarpetWriteConfiguration config = config().timeUnit(MICROS).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message TimeRecord {
+                      optional int64 localTime (TIME(MICROS,true));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nanos() {
+            var rootType = writeRecordModel(TimeRecord.class)
+                    .withField("localTime", LOCAL_TIME, TimeRecord::localTime);
+
+            CarpetWriteConfiguration config = config().timeUnit(NANOS).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message TimeRecord {
+                      optional int64 localTime (TIME(NANOS,true));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class TimeStampDefinition {
+
+        @Nested
+        class InstantDefinition {
+
+            record TimeStampRecord(Instant instant) {
+            }
+
+            @Test
+            void millis() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("instant", INSTANT, TimeStampRecord::instant);
+
+                CarpetWriteConfiguration config = config().timeUnit(MILLIS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(MILLIS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void micros() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("instant", INSTANT, TimeStampRecord::instant);
+
+                CarpetWriteConfiguration config = config().timeUnit(MICROS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(MICROS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void nanos() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("instant", INSTANT, TimeStampRecord::instant);
+
+                CarpetWriteConfiguration config = config().timeUnit(NANOS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 instant (TIMESTAMP(NANOS,true));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+        }
+
+        @Nested
+        class LocalDateTimeDefinition {
+
+            record TimeStampRecord(LocalDateTime localdDateTime) {
+            }
+
+            @Test
+            void millis() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("localdDateTime", LOCAL_DATE_TIME, TimeStampRecord::localdDateTime);
+
+                CarpetWriteConfiguration config = config().timeUnit(MILLIS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(MILLIS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void micros() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("localdDateTime", LOCAL_DATE_TIME, TimeStampRecord::localdDateTime);
+
+                CarpetWriteConfiguration config = config().timeUnit(MICROS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(MICROS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+
+            @Test
+            void nanos() {
+                var rootType = writeRecordModel(TimeStampRecord.class)
+                        .withField("localdDateTime", LOCAL_DATE_TIME, TimeStampRecord::localdDateTime);
+
+                CarpetWriteConfiguration config = config().timeUnit(NANOS).build();
+                MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+                String expected = """
+                        message TimeStampRecord {
+                          optional int64 localdDateTime (TIMESTAMP(NANOS,false));
+                        }
+                        """;
+                assertEquals(expected, schema.toString());
+            }
+        }
+    }
+
+    @Nested
+    class SimpleComposition {
+
+        @Test
+        void simpleParentChildRecordTest() {
+            record ChildRecord(String key, int value) {
+            }
+            record ParentRecord(long id, String name, ChildRecord foo) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("key", STRING, ChildRecord::key)
+                    .withField("value", INTEGER.notNull(), ChildRecord::value);
+
+            var rootType = writeRecordModel(ParentRecord.class)
+                    .withField("id", LONG.notNull(), ParentRecord::id)
+                    .withField("name", STRING, ParentRecord::name)
+                    .withField("foo", childType, ParentRecord::foo);
+
+            String expected = """
+                    message ParentRecord {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional group foo {
+                        optional binary key (STRING);
+                        required int32 value;
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void notNullChildRecordTest() {
+            record ChildRecord(String key, int value) {
+            }
+            record NotNullChildRecord(long id, String name, ChildRecord foo) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("key", STRING, ChildRecord::key)
+                    .withField("value", INTEGER.notNull(), ChildRecord::value);
+
+            var rootType = writeRecordModel(NotNullChildRecord.class)
+                    .withField("id", LONG.notNull(), NotNullChildRecord::id)
+                    .withField("name", STRING, NotNullChildRecord::name)
+                    .withField("bar", childType.notNull(), NotNullChildRecord::foo);
+
+            String expected = """
+                    message NotNullChildRecord {
+                      required int64 id;
+                      optional binary name (STRING);
+                      required group bar {
+                        optional binary key (STRING);
+                        required int32 value;
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        // How can we test recursivity? Can we define two RecordType variables and
+        // reference to each other?
+
+    }
+
+    @Nested
+    class EnumTypes {
+
+        enum Status {
+            ACTIVE, INACTIVE, DELETED
+        }
+
+        @Test
+        void withEnum() {
+            record WithEnum(long id, String name, Status status) {
+            }
+
+            var rootType = writeRecordModel(WithEnum.class)
+                    .withField("id", LONG.notNull(), WithEnum::id)
+                    .withField("name", STRING, WithEnum::name)
+                    .withField("status", ENUM.ofType(Status.class), WithEnum::status);
+
+            String expected = """
+                    message WithEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void withNotNullEnum() {
+            record WithNotNullEnum(long id, String name, Status status) {
+            }
+
+            var rootType = writeRecordModel(WithNotNullEnum.class)
+                    .withField("id", LONG.notNull(), WithNotNullEnum::id)
+                    .withField("name", STRING, WithNotNullEnum::name)
+                    .withField("state", ENUM.ofType(Status.class).notNull(), WithNotNullEnum::status);
+
+            String expected = """
+                    message WithNotNullEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      required binary state (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+    }
+
+    @Nested
+    class UuidTypes {
+
+        @Test
+        void withUuid() {
+            record WithUuid(UUID id, String name) {
+            }
+
+            var rootType = writeRecordModel(WithUuid.class)
+                    .withField("id", UUID, WithUuid::id)
+                    .withField("name", STRING, WithUuid::name);
+
+            String expected = """
+                    message WithUuid {
+                      optional fixed_len_byte_array(16) id (UUID);
+                      optional binary name (STRING);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void withNotNullEnum() {
+            record WithNotNullUuid(UUID id, String name) {
+            }
+
+            var rootType = writeRecordModel(WithNotNullUuid.class)
+                    .withField("id", UUID.notNull(), WithNotNullUuid::id)
+                    .withField("name", STRING, WithNotNullUuid::name);
+
+            String expected = """
+                    message WithNotNullUuid {
+                      required fixed_len_byte_array(16) id (UUID);
+                      optional binary name (STRING);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+    }
+
+    @Nested
+    class NestedCollection1Level {
+
+        @Test
+        void nestedSimpleTypeCollection() {
+            record SimpleTypeCollection(String id, List<Integer> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(INTEGER), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.ONE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated int32 values;
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedCollections() {
+            record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.ONE).build();
+
+            assertThrows(RecordTypeConversionException.class,
+                    () -> new WriteRecordModel2Schema(config).createSchema(rootType));
+        }
+
+        @Test
+        void nonConsecutiveNestedCollections() {
+            record ChildCollection(String name, List<String> alias) {
+            }
+            record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+            }
+
+            var child = writeRecordModel(ChildCollection.class)
+                    .withField("name", STRING, ChildCollection::name)
+                    .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+            var rootType = writeRecordModel(NonConsecutiveNestedCollection.class)
+                    .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(child), NonConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.ONE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NonConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      repeated group values {
+                        optional binary name (STRING);
+                        repeated binary alias (STRING);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedMapInCollection() {
+            record MapInCollection(String name, List<Map<String, Integer>> ids) {
+            }
+
+            var rootType = writeRecordModel(MapInCollection.class)
+                    .withField("name", STRING, MapInCollection::name)
+                    .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+            var config = config().annotatedLevels(AnnotatedLevels.ONE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message MapInCollection {
+                      optional binary name (STRING);
+                      repeated group ids (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional int32 value;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class NestedCollection2Level {
+
+        @Test
+        void nestedSimpleTypeCollection() {
+            record SimpleTypeCollection(String id, List<Integer> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(INTEGER), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated int32 element;
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record NestedRecordCollection(String id, List<ChildRecord> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(NestedRecordCollection.class)
+                    .withField("id", STRING, NestedRecordCollection::id)
+                    .withField("values", LIST.ofType(childType), NestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element {
+                          optional binary id (STRING);
+                          optional boolean loaded;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedOneTupleCollection() {
+            record OneTuple(String str) {
+            }
+            record NestedOneTupleCollection(String id, List<OneTuple> my_list) {
+            }
+
+            var childType = writeRecordModel(OneTuple.class)
+                    .withField("str", STRING, OneTuple::str);
+
+            var rootType = writeRecordModel(NestedOneTupleCollection.class)
+                    .withField("id", STRING, NestedOneTupleCollection::id)
+                    .withField("my_list", LIST.ofType(childType), NestedOneTupleCollection::my_list);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NestedOneTupleCollection {
+                      optional binary id (STRING);
+                      optional group my_list (LIST) {
+                        repeated group element {
+                          optional binary str (STRING);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveNestedRecordCollection(String id, List<List<ChildRecord>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveNestedRecordCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedRecordCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(childType)),
+                            ConsecutiveNestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveNestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element (LIST) {
+                          repeated group element {
+                            optional binary id (STRING);
+                            optional boolean loaded;
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveTripleNestedRecordCollection(String id, List<List<List<ChildRecord>>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedRecordCollection.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedRecordCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(LIST.ofType(childType))),
+                            ConsecutiveTripleNestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveTripleNestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element (LIST) {
+                          repeated group element (LIST) {
+                            repeated group element {
+                              optional binary id (STRING);
+                              optional boolean loaded;
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedSimpleTypeCollections() {
+            record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element (LIST) {
+                          repeated int32 element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedSimpleTypeCollections() {
+            record ConsecutiveTripleNestedCollection(String id, List<List<List<Integer>>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(LIST.ofType(INTEGER))),
+                            ConsecutiveTripleNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveTripleNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element (LIST) {
+                          repeated group element (LIST) {
+                            repeated int32 element;
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nonConsecutiveNestedCollections() {
+            record ChildCollection(String name, List<String> alias) {
+            }
+            record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+            }
+
+            var childType = writeRecordModel(ChildCollection.class)
+                    .withField("name", STRING, ChildCollection::name)
+                    .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+            var rootType = writeRecordModel(NonConsecutiveNestedCollection.class)
+                    .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(childType), NonConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NonConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group element {
+                          optional binary name (STRING);
+                          optional group alias (LIST) {
+                            repeated binary element (STRING);
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedMapInCollection() {
+            record MapInCollection(String name, List<Map<String, Integer>> ids) {
+            }
+
+            var rootType = writeRecordModel(MapInCollection.class)
+                    .withField("name", STRING, MapInCollection::name)
+                    .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+            var config = config().annotatedLevels(AnnotatedLevels.TWO).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message MapInCollection {
+                      optional binary name (STRING);
+                      optional group ids (LIST) {
+                        repeated group element (MAP) {
+                          repeated group key_value {
+                            required binary key (STRING);
+                            optional int32 value;
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class NestedCollection3Level {
+
+        @Test
+        void nestedIntegerCollection() {
+            record SimpleTypeCollection(String id, List<Integer> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(INTEGER), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional int32 element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedLongCollection() {
+            record SimpleTypeCollection(String id, List<Long> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(LONG), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional int64 element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedFloatCollection() {
+            record SimpleTypeCollection(String id, List<Float> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(FLOAT), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional float element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedDoubleCollection() {
+            record SimpleTypeCollection(String id, List<Double> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(DOUBLE), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional double element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBooleanCollection() {
+            record SimpleTypeCollection(String id, List<Boolean> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(BOOLEAN), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional boolean element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedShortCollection() {
+            record SimpleTypeCollection(String id, List<Short> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(SHORT), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional int32 element (INTEGER(16,true));
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedByteCollection() {
+            record SimpleTypeCollection(String id, List<Byte> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeCollection.class)
+                    .withField("id", STRING, SimpleTypeCollection::id)
+                    .withField("values", LIST.ofType(BYTE), SimpleTypeCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional int32 element (INTEGER(8,true));
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record NestedRecordCollection(String id, List<ChildRecord> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(NestedRecordCollection.class)
+                    .withField("id", STRING, NestedRecordCollection::id)
+                    .withField("values", LIST.ofType(childType), NestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element {
+                            optional binary id (STRING);
+                            optional boolean loaded;
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveNestedRecordCollection(String id, List<List<ChildRecord>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveNestedRecordCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedRecordCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(childType)),
+                            ConsecutiveNestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveNestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional group element {
+                                optional binary id (STRING);
+                                optional boolean loaded;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedRecordCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+
+            }
+            record ConsecutiveTripleNestedRecordCollection(String id, List<List<List<ChildRecord>>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedRecordCollection.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedRecordCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(LIST.ofType(childType))),
+                            ConsecutiveTripleNestedRecordCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveTripleNestedRecordCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional group element (LIST) {
+                                repeated group list {
+                                  optional group element {
+                                    optional binary id (STRING);
+                                    optional boolean loaded;
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedSimpleTypeCollections() {
+            record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional int32 element;
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedSimpleTypeCollections() {
+            record ConsecutiveTripleNestedCollection(String id, List<List<List<Integer>>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedCollection::id)
+                    .withField("values", LIST.ofType(LIST.ofType(LIST.ofType(INTEGER))),
+                            ConsecutiveTripleNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message ConsecutiveTripleNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional group element (LIST) {
+                                repeated group list {
+                                  optional int32 element;
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nonConsecutiveNestedCollections() {
+            record ChildCollection(String name, List<String> alias) {
+            }
+            record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+            }
+
+            var childType = writeRecordModel(ChildCollection.class)
+                    .withField("name", STRING, ChildCollection::name)
+                    .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+            var rootType = writeRecordModel(NonConsecutiveNestedCollection.class)
+                    .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                    .withField("values", LIST.ofType(childType), NonConsecutiveNestedCollection::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message NonConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element {
+                            optional binary name (STRING);
+                            optional group alias (LIST) {
+                              repeated group list {
+                                optional binary element (STRING);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void collectionWithNestedMap() {
+            record CollectionWithNestedMap(String id, List<Map<String, Integer>> values) {
+            }
+
+            var rootType = writeRecordModel(CollectionWithNestedMap.class)
+                    .withField("id", STRING, CollectionWithNestedMap::id)
+                    .withField("values", LIST.ofType(MAP.ofTypes(STRING, INTEGER)),
+                            CollectionWithNestedMap::values);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message CollectionWithNestedMap {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional int32 value;
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedMapInCollection() {
+            record MapInCollection(String name, List<Map<String, Integer>> ids) {
+            }
+
+            var rootType = writeRecordModel(MapInCollection.class)
+                    .withField("name", STRING, MapInCollection::name)
+                    .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+            var config = config().annotatedLevels(AnnotatedLevels.THREE).build();
+            MessageType schema = new WriteRecordModel2Schema(config).createSchema(rootType);
+
+            String expected = """
+                    message MapInCollection {
+                      optional binary name (STRING);
+                      optional group ids (LIST) {
+                        repeated group list {
+                          optional group element (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional int32 value;
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+    }
+
+    @Nested
+    class NestedMaps {
+
+        @Test
+        void nestedSimpleTypeMap() {
+            record SimpleTypeMap(String id, Map<String, Integer> values) {
+            }
+
+            var rootType = writeRecordModel(SimpleTypeMap.class)
+                    .withField("id", STRING, SimpleTypeMap::id)
+                    .withField("values", MAP.ofTypes(STRING, INTEGER), SimpleTypeMap::values);
+
+            String expected = """
+                    message SimpleTypeMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional int32 value;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void nestedRecordMap() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record NestedRecordMap(String id, Map<String, ChildRecord> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(NestedRecordMap.class)
+                    .withField("id", STRING, NestedRecordMap::id)
+                    .withField("values", MAP.ofTypes(STRING, childType), NestedRecordMap::values);
+
+            String expected = """
+                    message NestedRecordMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value {
+                            optional binary id (STRING);
+                            optional boolean loaded;
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void mapWithKeyRecord() {
+            record KeyRecord(String id, String category) {
+            }
+            record SimpleTypeMap(String id, Map<KeyRecord, String> values) {
+            }
+
+            var childType = writeRecordModel(KeyRecord.class)
+                    .withField("id", STRING, KeyRecord::id)
+                    .withField("category", STRING, KeyRecord::category);
+
+            var rootType = writeRecordModel(SimpleTypeMap.class)
+                    .withField("id", STRING, SimpleTypeMap::id)
+                    .withField("values", MAP.ofTypes(childType, STRING), SimpleTypeMap::values);
+
+            String expected = """
+                    message SimpleTypeMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required group key {
+                            optional binary id (STRING);
+                            optional binary category (STRING);
+                          }
+                          optional binary value (STRING);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void consecutiveNestedRecordMap() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveNestedRecordMap(String id, Map<String, Map<String, ChildRecord>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveNestedRecordMap.class)
+                    .withField("id", STRING, ConsecutiveNestedRecordMap::id)
+                    .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, childType)),
+                            ConsecutiveNestedRecordMap::values);
+
+            String expected = """
+                    message ConsecutiveNestedRecordMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional group value {
+                                optional binary id (STRING);
+                                optional boolean loaded;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void consecutiveNestedMapCollection() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveNestedRecordMap(String id, Map<String, List<ChildRecord>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveNestedRecordMap.class)
+                    .withField("id", STRING, ConsecutiveNestedRecordMap::id)
+                    .withField("values", MAP.ofTypes(STRING, LIST.ofType(childType)),
+                            ConsecutiveNestedRecordMap::values);
+
+            String expected = """
+                    message ConsecutiveNestedRecordMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value (LIST) {
+                            repeated group list {
+                              optional group element {
+                                optional binary id (STRING);
+                                optional boolean loaded;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedMap() {
+            record ChildRecord(String id, Boolean loaded) {
+            }
+            record ConsecutiveTripleNestedMap(String id, Map<String, Map<String, Map<String, ChildRecord>>> values) {
+            }
+
+            var childType = writeRecordModel(ChildRecord.class)
+                    .withField("id", STRING, ChildRecord::id)
+                    .withField("loaded", BOOLEAN, ChildRecord::loaded);
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedMap.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedMap::id)
+                    .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, MAP.ofTypes(STRING, childType))),
+                            ConsecutiveTripleNestedMap::values);
+
+            String expected = """
+                    message ConsecutiveTripleNestedMap {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional group value (MAP) {
+                                repeated group key_value {
+                                  required binary key (STRING);
+                                  optional group value {
+                                    optional binary id (STRING);
+                                    optional boolean loaded;
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void consecutiveNestedSimpleTypeMap() {
+            record ConsecutiveNestedCollection(String id, Map<String, Map<String, Integer>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveNestedCollection::id)
+                    .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER)),
+                            ConsecutiveNestedCollection::values);
+
+            String expected = """
+                    message ConsecutiveNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional int32 value;
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedSimpleTypeMap() {
+            record ConsecutiveTripleNestedCollection(String id, Map<String, Map<String, Map<String, Integer>>> values) {
+            }
+
+            var rootType = writeRecordModel(ConsecutiveTripleNestedCollection.class)
+                    .withField("id", STRING, ConsecutiveTripleNestedCollection::id)
+                    .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER))),
+                            ConsecutiveTripleNestedCollection::values);
+
+            String expected = """
+                    message ConsecutiveTripleNestedCollection {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value (MAP) {
+                            repeated group key_value {
+                              required binary key (STRING);
+                              optional group value (MAP) {
+                                repeated group key_value {
+                                  required binary key (STRING);
+                                  optional int32 value;
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void nonConsecutiveNestedMaps() {
+            record ChildCollection(String name, Map<Integer, Long> alias) {
+            }
+            record NonConsecutiveNestedMaps(String id, Map<String, ChildCollection> values) {
+            }
+
+            var childType = writeRecordModel(ChildCollection.class)
+                    .withField("name", STRING, ChildCollection::name)
+                    .withField("alias", MAP.ofTypes(INTEGER, LONG), ChildCollection::alias);
+
+            var rootType = writeRecordModel(NonConsecutiveNestedMaps.class)
+                    .withField("id", STRING, NonConsecutiveNestedMaps::id)
+                    .withField("values", MAP.ofTypes(STRING, childType), NonConsecutiveNestedMaps::values);
+
+            String expected = """
+                    message NonConsecutiveNestedMaps {
+                      optional binary id (STRING);
+                      optional group values (MAP) {
+                        repeated group key_value {
+                          required binary key (STRING);
+                          optional group value {
+                            optional binary name (STRING);
+                            optional group alias (MAP) {
+                              repeated group key_value {
+                                required int32 key;
+                                optional int64 value;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+    }
+
+    public static ConfigurationBuilder config() {
+        return new ConfigurationBuilder();
+    }
+
+    public static CarpetWriteConfiguration defaultConfig() {
+        return new ConfigurationBuilder().build();
+    }
+
+    public static MessageType schemaWithRootType(WriteRecordModelType<?> rootType) {
+        return new WriteRecordModel2Schema(defaultConfig()).createSchema(rootType);
+    }
+
+    static class ConfigurationBuilder {
+
+        private AnnotatedLevels annotatedLevels = AnnotatedLevels.THREE;
+        private TimeUnit timeUnit = TimeUnit.MILLIS;
+        private DecimalConfig decimalConfig;
+
+        public ConfigurationBuilder annotatedLevels(AnnotatedLevels annotatedLevels) {
+            this.annotatedLevels = annotatedLevels;
+            return this;
+        }
+
+        public ConfigurationBuilder timeUnit(TimeUnit timeUnit) {
+            this.timeUnit = timeUnit;
+            return this;
+        }
+
+        public ConfigurationBuilder decimalConfig(DecimalConfig decimalConfig) {
+            this.decimalConfig = decimalConfig;
+            return this;
+        }
+
+        public CarpetWriteConfiguration build() {
+            return new CarpetWriteConfiguration(annotatedLevels, ColumnNamingStrategy.FIELD_NAME, timeUnit,
+                    decimalConfig);
+        }
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/model/WriteRecordTypeTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/model/WriteRecordTypeTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.WriteRecordModelType.writeRecordModel;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class WriteRecordTypeTest {
+
+    record RootRecord(String id, Integer value) {
+    }
+
+    @Test
+    void fieldNameCanNotBeRepeated() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            writeRecordModel(RootRecord.class)
+                    .withField("id", STRING, RootRecord::id)
+                    .withField("id", INTEGER, RootRecord::value);
+        });
+    }
+
+    @Test
+    void fieldTypeConsistencyIsNotVerified() {
+        assertDoesNotThrow(() -> {
+            writeRecordModel(RootRecord.class)
+                    .withField("id", STRING, RootRecord::id)
+                    .withField("value", STRING, RootRecord::value);
+        });
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionOneLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionOneLevelTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.writer;
+
+import static com.jerolba.carpet.AnnotatedLevels.ONE;
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.SET;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.ParquetWriterTest;
+import com.jerolba.carpet.RecordTypeConversionException;
+
+class WriteRecordModelWriterCollectionOneLevelTest {
+
+    @Test
+    void simpleTypeCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Integer> ids, List<Double> amount) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), SimpleTypeCollection::ids)
+                .withField("amount", LIST.ofType(DOUBLE), SimpleTypeCollection::amount);
+
+        var rec = new SimpleTypeCollection("foo", List.of(1, 2, 3), List.of(1.2, 3.2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void emptyCollectionIsTransformedToNull() throws IOException {
+
+        record EmptyCollection(String name, List<Integer> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyCollection.class)
+                .withField("name", STRING, EmptyCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), EmptyCollection::ids);
+
+        var rec = new EmptyCollection("foo", List.of());
+        var writerTest = new ParquetWriterTest<>(EmptyCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyCollection expectedNullList = new EmptyCollection("foo", null);
+        assertEquals(expectedNullList, carpetReader.read());
+    }
+
+    @Test
+    void consecutiveNestedCollectionsAreNotSupported() {
+
+        record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+        }
+
+        var mapper = writeRecordModel(ConsecutiveNestedCollection.class)
+                .withField("id", STRING, ConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+        var rec = new ConsecutiveNestedCollection("foo", List.of(List.of(1, 2, 3)));
+        assertThrows(RecordTypeConversionException.class, () -> {
+            var writerTest = new ParquetWriterTest<>(ConsecutiveNestedCollection.class).withLevel(ONE);
+            writerTest.write(mapper, rec);
+        });
+    }
+
+    @Test
+    void simpleCompositeCollection() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record SimpleCompositeCollection(String name, List<ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(SimpleCompositeCollection.class)
+                .withField("name", STRING, SimpleCompositeCollection::name)
+                .withField("ids", LIST.ofType(child), SimpleCompositeCollection::ids);
+
+        var rec = new SimpleCompositeCollection("foo",
+                List.of(new ChildRecord("Madrid", true), new ChildRecord("Sevilla", false)));
+        var writerTest = new ParquetWriterTest<>(SimpleCompositeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nonConsecutiveNestedCollections() throws IOException {
+
+        record ChildCollection(String name, List<String> alias) {
+        }
+        record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+        }
+
+        var child = writeRecordModel(ChildCollection.class)
+                .withField("name", STRING, ChildCollection::name)
+                .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+        var mapper = writeRecordModel(NonConsecutiveNestedCollection.class)
+                .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(child), NonConsecutiveNestedCollection::values);
+
+        var rec = new NonConsecutiveNestedCollection("foo",
+                List.of(new ChildCollection("Apple", List.of("MacOs", "OS X"))));
+        var writerTest = new ParquetWriterTest<>(NonConsecutiveNestedCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nestedMapInCollection() throws IOException {
+
+        record MapInCollection(String name, List<Map<String, Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(MapInCollection.class)
+                .withField("name", STRING, MapInCollection::name)
+                .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+        var rec = new MapInCollection("foo",
+                List.of(Map.of("1", 1, "2", 2, "3", 3), Map.of("1", 10, "2", 20, "3", 30)));
+        var writerTest = new ParquetWriterTest<>(MapInCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void setCollectionAsListIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", LIST.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+    @Test
+    void setCollectionAsSetIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", SET.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionThreeLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionThreeLevelTest.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.writer;
+
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.SET;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.ParquetWriterTest;
+
+class WriteRecordModelWriterCollectionThreeLevelTest {
+
+    @Test
+    void simpleTypeCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Integer> ids, List<Double> amount) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), SimpleTypeCollection::ids)
+                .withField("amount", LIST.ofType(DOUBLE), SimpleTypeCollection::amount);
+
+        var rec = new SimpleTypeCollection("foo", List.of(1, 2, 3), List.of(1.2, 3.2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void consecutiveNestedCollections() throws IOException {
+
+        record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+        }
+
+        var mapper = writeRecordModel(ConsecutiveNestedCollection.class)
+                .withField("id", STRING, ConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+        var rec = new ConsecutiveNestedCollection("foo", List.of(List.of(1, 2, 3)));
+        var writerTest = new ParquetWriterTest<>(ConsecutiveNestedCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleCompositeCollection() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record SimpleCompositeCollection(String name, List<ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(SimpleCompositeCollection.class)
+                .withField("name", STRING, SimpleCompositeCollection::name)
+                .withField("ids", LIST.ofType(child), SimpleCompositeCollection::ids);
+
+        var rec = new SimpleCompositeCollection("foo",
+                List.of(new ChildRecord("Madrid", true), new ChildRecord("Sevilla", false)));
+        var writerTest = new ParquetWriterTest<>(SimpleCompositeCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void consecutiveNestedCompositeCollection() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record ConsecutiveNestedCompositeCollection(String name, List<List<ChildRecord>> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(ConsecutiveNestedCompositeCollection.class)
+                .withField("name", STRING, ConsecutiveNestedCompositeCollection::name)
+                .withField("ids", LIST.ofType(LIST.ofType(child)), ConsecutiveNestedCompositeCollection::ids);
+
+        var rec = new ConsecutiveNestedCompositeCollection("foo",
+                List.of(List.of(new ChildRecord("Madrid", true), new ChildRecord("Sevilla", false))));
+        var writerTest = new ParquetWriterTest<>(ConsecutiveNestedCompositeCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nonConsecutiveNestedCollections() throws IOException {
+
+        record ChildCollection(String name, List<String> alias) {
+        }
+        record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+        }
+
+        var child = writeRecordModel(ChildCollection.class)
+                .withField("name", STRING, ChildCollection::name)
+                .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+        var mapper = writeRecordModel(NonConsecutiveNestedCollection.class)
+                .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(child), NonConsecutiveNestedCollection::values);
+
+        var rec = new NonConsecutiveNestedCollection("foo",
+                List.of(new ChildCollection("Apple", List.of("MacOs", "OS X"))));
+        var writerTest = new ParquetWriterTest<>(NonConsecutiveNestedCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nestedMapInCollection() throws IOException {
+
+        record MapInCollection(String name, List<Map<String, Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(MapInCollection.class)
+                .withField("name", STRING, MapInCollection::name)
+                .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+        var rec = new MapInCollection("foo",
+                List.of(Map.of("1", 1, "2", 2, "3", 3), Map.of("1", 10, "2", 20, "3", 30)));
+        var writerTest = new ParquetWriterTest<>(MapInCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void emptyCollectionIsTransformedToEmptyCollection() throws IOException {
+
+        record EmptyCollection(String name, List<Integer> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyCollection.class)
+                .withField("name", STRING, EmptyCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), EmptyCollection::ids);
+
+        var rec = new EmptyCollection("foo", List.of());
+        var writerTest = new ParquetWriterTest<>(EmptyCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyCollection expectedNullList = new EmptyCollection("foo", emptyList());
+        assertEquals(expectedNullList, carpetReader.read());
+    }
+
+    @Test
+    void emptyNestedCollectionIsSupported() throws IOException {
+
+        record EmptyNestedCollection(String name, List<List<Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedCollection.class)
+                .withField("name", STRING, EmptyNestedCollection::name)
+                .withField("ids", LIST.ofType(LIST.ofType(INTEGER)), EmptyNestedCollection::ids);
+
+        var rec = new EmptyNestedCollection("foo", List.of(List.of()));
+        var writerTest = new ParquetWriterTest<>(EmptyNestedCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyNestedCollection expected = new EmptyNestedCollection("foo", List.of(List.of()));
+        assertEquals(expected, carpetReader.read());
+    }
+
+    @Test
+    void mixedCollection() throws IOException {
+
+        record WithCollection(String name, List<Integer> ids) {
+        }
+
+        var mapper = writeRecordModel(WithCollection.class)
+                .withField("name", STRING, WithCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), WithCollection::ids);
+
+        var writerTest = new ParquetWriterTest<>(WithCollection.class);
+        writerTest.write(mapper,
+                new WithCollection("foo", null),
+                new WithCollection("bar", List.of()),
+                new WithCollection("baz", List.of(1, 2, 3)),
+                new WithCollection("baz", asList(1, null, 3)));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(new WithCollection("foo", null), carpetReader.read());
+        assertEquals(new WithCollection("bar", List.of()), carpetReader.read());
+        assertEquals(new WithCollection("baz", List.of(1, 2, 3)), carpetReader.read());
+        assertEquals(new WithCollection("baz", asList(1, null, 3)), carpetReader.read());
+    }
+
+    @Test
+    void setCollectionAsListIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", LIST.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+    @Test
+    void setCollectionAsSetIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", SET.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.writer;
+
+import static com.jerolba.carpet.AnnotatedLevels.TWO;
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.SET;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.ParquetWriterTest;
+
+class WriteRecordModelWriterCollectionTwoLevelTest {
+
+    @Test
+    void simpleTypeCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Integer> ids, List<Double> amount) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), SimpleTypeCollection::ids)
+                .withField("amount", LIST.ofType(DOUBLE), SimpleTypeCollection::amount);
+
+        var rec = new SimpleTypeCollection("foo", List.of(1, 2, 3), List.of(1.2, 3.2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void consecutiveNestedCollections() throws IOException {
+
+        record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
+        }
+
+        var mapper = writeRecordModel(ConsecutiveNestedCollection.class)
+                .withField("id", STRING, ConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(LIST.ofType(INTEGER)), ConsecutiveNestedCollection::values);
+
+        var rec = new ConsecutiveNestedCollection("foo", List.of(List.of(1, 2, 3)));
+        var writerTest = new ParquetWriterTest<>(ConsecutiveNestedCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleCompositeCollection() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record SimpleCompositeCollection(String name, List<ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(SimpleCompositeCollection.class)
+                .withField("name", STRING, SimpleCompositeCollection::name)
+                .withField("ids", LIST.ofType(child), SimpleCompositeCollection::ids);
+
+        var rec = new SimpleCompositeCollection("foo",
+                List.of(new ChildRecord("Madrid", true), new ChildRecord("Sevilla", false)));
+        var writerTest = new ParquetWriterTest<>(SimpleCompositeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void consecutiveNestedCompositeCollection() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record ConsecutiveNestedCompositeCollection(String name, List<List<ChildRecord>> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(ConsecutiveNestedCompositeCollection.class)
+                .withField("name", STRING, ConsecutiveNestedCompositeCollection::name)
+                .withField("ids", LIST.ofType(LIST.ofType(child)), ConsecutiveNestedCompositeCollection::ids);
+
+        var rec = new ConsecutiveNestedCompositeCollection("foo",
+                List.of(List.of(new ChildRecord("Madrid", true), new ChildRecord("Sevilla", false))));
+        var writerTest = new ParquetWriterTest<>(ConsecutiveNestedCompositeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nonConsecutiveNestedCollections() throws IOException {
+
+        record ChildCollection(String name, List<String> alias) {
+        }
+        record NonConsecutiveNestedCollection(String id, List<ChildCollection> values) {
+        }
+
+        var child = writeRecordModel(ChildCollection.class)
+                .withField("name", STRING, ChildCollection::name)
+                .withField("alias", LIST.ofType(STRING), ChildCollection::alias);
+
+        var mapper = writeRecordModel(NonConsecutiveNestedCollection.class)
+                .withField("id", STRING, NonConsecutiveNestedCollection::id)
+                .withField("values", LIST.ofType(child), NonConsecutiveNestedCollection::values);
+
+        var rec = new NonConsecutiveNestedCollection("foo",
+                List.of(new ChildCollection("Apple", List.of("MacOs", "OS X"))));
+        var writerTest = new ParquetWriterTest<>(NonConsecutiveNestedCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nestedMapInCollection() throws IOException {
+
+        record MapInCollection(String name, List<Map<String, Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(MapInCollection.class)
+                .withField("name", STRING, MapInCollection::name)
+                .withField("ids", LIST.ofType(MAP.ofTypes(STRING, INTEGER)), MapInCollection::ids);
+
+        var rec = new MapInCollection("foo",
+                List.of(Map.of("1", 1, "2", 2, "3", 3), Map.of("1", 10, "2", 20, "3", 30)));
+        var writerTest = new ParquetWriterTest<>(MapInCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void emptyCollectionIsTransformedToEmptyCollection() throws IOException {
+
+        record EmptyCollection(String name, List<Integer> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyCollection.class)
+                .withField("name", STRING, EmptyCollection::name)
+                .withField("ids", LIST.ofType(INTEGER), EmptyCollection::ids);
+
+        var rec = new EmptyCollection("foo", List.of());
+        var writerTest = new ParquetWriterTest<>(EmptyCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyCollection expectedNullList = new EmptyCollection("foo", emptyList());
+        assertEquals(expectedNullList, carpetReader.read());
+    }
+
+    @Test
+    void emptyNestedCollectionsAreSupported() throws IOException {
+
+        record EmptyNestedCollection(String name, List<List<Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedCollection.class)
+                .withField("name", STRING, EmptyNestedCollection::name)
+                .withField("ids", LIST.ofType(LIST.ofType(INTEGER)), EmptyNestedCollection::ids);
+
+        var rec = new EmptyNestedCollection("foo", List.of(List.of()));
+        var writerTest = new ParquetWriterTest<>(EmptyNestedCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+        assertEquals(List.of(List.of()), avroRecord.get("ids"));
+    }
+
+    @Test
+    void setCollectionAsListIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", LIST.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+    @Test
+    void setCollectionAsSetIsSupported() throws IOException {
+
+        record SetCollection(String name, Set<String> ids) {
+        }
+
+        var mapper = writeRecordModel(SetCollection.class)
+                .withField("name", STRING, SetCollection::name)
+                .withField("ids", SET.ofType(STRING), SetCollection::ids);
+
+        var ids = List.of("ONE", "TWO", "THREE");
+        var rec = new SetCollection("foo", new HashSet<>(ids));
+        var writerTest = new ParquetWriterTest<>(SetCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        record ListCollection(String name, List<String> ids) {
+        }
+
+        var carpetReader = writerTest.getCarpetReader(ListCollection.class);
+        assertEquals(new ListCollection("foo", ids), carpetReader.read());
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterMapTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterMapTest.java
@@ -1,0 +1,461 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.writer;
+
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.MAP;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.parquet.io.InvalidRecordException;
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.ParquetWriterTest;
+
+class WriteRecordModelWriterMapTest {
+
+    @Test
+    void mapPrimitiveValue() throws IOException {
+
+        record MapPrimitiveValue(String name, Map<String, Integer> ids, Map<String, Double> amount) {
+        }
+
+        var mapper = writeRecordModel(MapPrimitiveValue.class)
+                .withField("name", STRING, MapPrimitiveValue::name)
+                .withField("ids", MAP.ofTypes(STRING, INTEGER), MapPrimitiveValue::ids)
+                .withField("amount", MAP.ofTypes(STRING, DOUBLE), MapPrimitiveValue::amount);
+
+        var rec1 = new MapPrimitiveValue("foo", mapOf("ABCD", 1, "EFGH", 2), mapOf("ABCD", 1.2, "EFGH", 2.3));
+        var rec2 = new MapPrimitiveValue("bar", mapOf("ABCD", 3, "EFGH", 4), mapOf("ABCD", 2.2, "EFGH", 3.3));
+        var writerTest = new ParquetWriterTest<>(MapPrimitiveValue.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapPrimitiveValueNull() throws IOException {
+
+        record MapPrimitiveValueNull(String name, Map<String, Integer> ids, Map<String, Double> amount) {
+        }
+
+        var mapper = writeRecordModel(MapPrimitiveValueNull.class)
+                .withField("name", STRING, MapPrimitiveValueNull::name)
+                .withField("ids", MAP.ofTypes(STRING, INTEGER), MapPrimitiveValueNull::ids)
+                .withField("amount", MAP.ofTypes(STRING, DOUBLE), MapPrimitiveValueNull::amount);
+
+        var rec1 = new MapPrimitiveValueNull("foo", mapOf("ABCD", 1, "EFGH", 2), mapOf("ABCD", 1.2, "EFGH", 2.3));
+        var rec2 = new MapPrimitiveValueNull("bar", mapOf("ABCD", null, "EFGH", 4), mapOf("ABCD", 2.2, "EFGH", null));
+        var writerTest = new ParquetWriterTest<>(MapPrimitiveValueNull.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapRecordValue() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record MapRecordValue(String name, Map<String, ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(MapRecordValue.class)
+                .withField("name", STRING, MapRecordValue::name)
+                .withField("ids", MAP.ofTypes(STRING, child), MapRecordValue::ids);
+
+        var rec1 = new MapRecordValue("AVE", mapOf(
+                "MAD", new ChildRecord("Madrid", true),
+                "ZGZ", new ChildRecord("Zaragoza", false)));
+        var rec2 = new MapRecordValue("AVE", mapOf(
+                "MAD", new ChildRecord("Madrid", false),
+                "CAT", new ChildRecord("Barcelona", true)));
+        var writerTest = new ParquetWriterTest<>(MapRecordValue.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapRecordValueNull() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record MapRecordValueNull(String name, Map<String, ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(MapRecordValueNull.class)
+                .withField("name", STRING, MapRecordValueNull::name)
+                .withField("ids", MAP.ofTypes(STRING, child), MapRecordValueNull::ids);
+
+        var rec1 = new MapRecordValueNull("AVE", mapOf(
+                "MAD", new ChildRecord("Madrid", true),
+                "ZGZ", new ChildRecord("Zaragoza", false)));
+        var rec2 = new MapRecordValueNull("AVE", mapOf(
+                "MAD", new ChildRecord("Madrid", true),
+                "BDJ", null));
+
+        var writerTest = new ParquetWriterTest<>(MapRecordValueNull.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapRecordKeyNull() {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record MapRecordValueNull(String name, Map<String, ChildRecord> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(MapRecordValueNull.class)
+                .withField("name", STRING, MapRecordValueNull::name)
+                .withField("ids", MAP.ofTypes(STRING, child), MapRecordValueNull::ids);
+
+        var rec1 = new MapRecordValueNull("AVE", mapOf(
+                "MAD", new ChildRecord("Madrid", true),
+                null, new ChildRecord("Heaven", false)));
+
+        var writerTest = new ParquetWriterTest<>(MapRecordValueNull.class);
+        assertThrows(InvalidRecordException.class, () -> writerTest.write(mapper, rec1));
+    }
+
+    @Test
+    void nestedMap_MapPrimitiveValue() throws IOException {
+
+        record NestedMap_MapPrimitiveValue(String id, Map<String, Map<String, Integer>> values) {
+        }
+
+        var mapper = writeRecordModel(NestedMap_MapPrimitiveValue.class)
+                .withField("id", STRING, NestedMap_MapPrimitiveValue::id)
+                .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER)),
+                        NestedMap_MapPrimitiveValue::values);
+
+        var rec1 = new NestedMap_MapPrimitiveValue("Plane", mapOf(
+                "ABCD", mapOf("EFGH", 10, "IJKL", 20),
+                "WXYZ", mapOf("EFGH", 30, "IJKL", 50)));
+        var rec2 = new NestedMap_MapPrimitiveValue("Boat", mapOf(
+                "ABCD", mapOf("EFGH", 40, "IJKL", 50),
+                "WXYZ", mapOf("EFGH", 70, "IJKL", 90)));
+        var writerTest = new ParquetWriterTest<>(NestedMap_MapPrimitiveValue.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void nestedMap_MapPrimitiveValueNull() throws IOException {
+
+        record NestedMap_MapPrimitiveValueNull(String id, Map<String, Map<String, Integer>> values) {
+        }
+
+        var mapper = writeRecordModel(NestedMap_MapPrimitiveValueNull.class)
+                .withField("id", STRING, NestedMap_MapPrimitiveValueNull::id)
+                .withField("values", MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER)),
+                        NestedMap_MapPrimitiveValueNull::values);
+
+        var rec1 = new NestedMap_MapPrimitiveValueNull("Plane", mapOf(
+                "ABCD", mapOf("EFGH", 10, "IJKL", 20),
+                "WXYZ", mapOf("EFGH", 30, "IJKL", 50)));
+        var rec2 = new NestedMap_MapPrimitiveValueNull("Boat", mapOf(
+                "ABCD", mapOf("EFGH", 40, "IJKL", null),
+                "WXYZ", null));
+        var writerTest = new ParquetWriterTest<>(NestedMap_MapPrimitiveValueNull.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void nestedMap_MapRecordValue() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record NestedMap_MapRecordValue(String name, Map<String, Map<String, ChildRecord>> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(NestedMap_MapRecordValue.class)
+                .withField("name", STRING, NestedMap_MapRecordValue::name)
+                .withField("ids", MAP.ofTypes(STRING, MAP.ofTypes(STRING, child)), NestedMap_MapRecordValue::ids);
+
+        var rec1 = new NestedMap_MapRecordValue("Trip", mapOf(
+                "AA", mapOf("FF", new ChildRecord("Madrid", true), "200", new ChildRecord("Sevilla", false)),
+                "BB", mapOf("JJ", new ChildRecord("Bilbao", false), "300", new ChildRecord("Zaragoza", false))));
+        var rec2 = new NestedMap_MapRecordValue("Hotel", mapOf(
+                "ZZ", mapOf("100", new ChildRecord("Madrid", true), "200", new ChildRecord("Sevilla", false)),
+                "YY", mapOf("200", new ChildRecord("Bilbao", false), "300", new ChildRecord("Zaragoza", false))));
+        var writerTest = new ParquetWriterTest<>(NestedMap_MapRecordValue.class);
+        writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void nestedMap_MapRecordValueNull() throws IOException {
+
+        record ChildRecord(String id, boolean active) {
+        }
+        record NestedMap_MapRecordValueNull(String name, Map<String, Map<String, ChildRecord>> ids) {
+        }
+
+        var child = writeRecordModel(ChildRecord.class)
+                .withField("id", STRING, ChildRecord::id)
+                .withField("active", BOOLEAN.notNull(), ChildRecord::active);
+
+        var mapper = writeRecordModel(NestedMap_MapRecordValueNull.class)
+                .withField("name", STRING, NestedMap_MapRecordValueNull::name)
+                .withField("ids", MAP.ofTypes(STRING, MAP.ofTypes(STRING, child)), NestedMap_MapRecordValueNull::ids);
+
+        var rec = new NestedMap_MapRecordValueNull("Hotel", mapOf(
+                "ZZ", mapOf("100", new ChildRecord("Madrid", true), "200", null),
+                "YY", null));
+        var writerTest = new ParquetWriterTest<>(NestedMap_MapRecordValueNull.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nestedMap_Record_Map() throws IOException {
+
+        record ChildWithMap(String name, Map<String, Integer> alias) {
+        }
+        record NestedMap_Record_Map(String id, Map<String, ChildWithMap> values) {
+        }
+
+        var child = writeRecordModel(ChildWithMap.class)
+                .withField("name", STRING, ChildWithMap::name)
+                .withField("alias", MAP.ofTypes(STRING, INTEGER), ChildWithMap::alias);
+
+        var mapper = writeRecordModel(NestedMap_Record_Map.class)
+                .withField("id", STRING, NestedMap_Record_Map::id)
+                .withField("values", MAP.ofTypes(STRING, child), NestedMap_Record_Map::values);
+
+        var rec = new NestedMap_Record_Map("foo", mapOf(
+                "OS", new ChildWithMap("Apple", mapOf("MacOs", 1000, "OS X", 2000)),
+                "CP", new ChildWithMap("MS", mapOf("Windows 10", 33, "Windows 11", 54))));
+        var writerTest = new ParquetWriterTest<>(NestedMap_Record_Map.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void mapKeyRecord() throws IOException {
+
+        record KeyRecord(String id, boolean active) {
+        }
+        record MapKeyRecord(String name, Map<KeyRecord, String> ids) {
+        }
+
+        var keyRecord = writeRecordModel(KeyRecord.class)
+                .withField("id", STRING, KeyRecord::id)
+                .withField("active", BOOLEAN.notNull(), KeyRecord::active);
+
+        var mapper = writeRecordModel(MapKeyRecord.class)
+                .withField("name", STRING, MapKeyRecord::name)
+                .withField("ids", MAP.ofTypes(keyRecord, STRING), MapKeyRecord::ids);
+
+        var rec = new MapKeyRecord("foo", mapOf(
+                new KeyRecord("Madrid", true), "MAD",
+                new KeyRecord("Barcelona", true), "BCN"));
+        var writerTest = new ParquetWriterTest<>(MapKeyRecord.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void mapKeyRecord_ValueRecord() throws IOException {
+
+        record KeyRecord(String id, boolean active) {
+        }
+        record ValueRecord(String id, int age) {
+        }
+        record MapKeyAndValueRecord(String name, Map<KeyRecord, ValueRecord> ids) {
+        }
+
+        var keyRecord = writeRecordModel(KeyRecord.class)
+                .withField("id", STRING, KeyRecord::id)
+                .withField("active", BOOLEAN.notNull(), KeyRecord::active);
+        var valueRecord = writeRecordModel(ValueRecord.class)
+                .withField("id", STRING, ValueRecord::id)
+                .withField("age", INTEGER.notNull(), ValueRecord::age);
+        var mapper = writeRecordModel(MapKeyAndValueRecord.class)
+                .withField("name", STRING, MapKeyAndValueRecord::name)
+                .withField("ids", MAP.ofTypes(keyRecord, valueRecord), MapKeyAndValueRecord::ids);
+
+        var rec = new MapKeyAndValueRecord("Time", mapOf(
+                new KeyRecord("Madrid", true), new ValueRecord("MAD", 10),
+                new KeyRecord("Barcelona", true), new ValueRecord("MAD", 10)));
+        var writerTest = new ParquetWriterTest<>(MapKeyAndValueRecord.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void emptyMapIsTransformedToEmptyMap() throws IOException {
+
+        record EmptyMap(String name, Map<String, Integer> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyMap.class)
+                .withField("name", STRING, EmptyMap::name)
+                .withField("ids", MAP.ofTypes(STRING, INTEGER), EmptyMap::ids);
+
+        var rec = new EmptyMap("foo", Map.of());
+        var writerTest = new ParquetWriterTest<>(EmptyMap.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyMap expectedEmptyMap = new EmptyMap("foo", emptyMap());
+        assertEquals(expectedEmptyMap, carpetReader.read());
+    }
+
+    @Test
+    void emptyNestedMapIsSupported() throws IOException {
+
+        record EmptyNestedMap(String name, Map<String, Map<String, Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedMap.class)
+                .withField("name", STRING, EmptyNestedMap::name)
+                .withField("ids", MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER)), EmptyNestedMap::ids);
+
+        var rec = new EmptyNestedMap("foo", Map.of("key", Map.of()));
+        var writerTest = new ParquetWriterTest<>(EmptyNestedMap.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyNestedMap expectedEmptyMap = new EmptyNestedMap("foo", Map.of("key", emptyMap()));
+        assertEquals(expectedEmptyMap, carpetReader.read());
+    }
+
+    @Test
+    void nullNestedMapIsSupported() throws IOException {
+
+        record EmptyNestedMap(String name, Map<String, Map<String, Integer>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedMap.class)
+                .withField("name", STRING, EmptyNestedMap::name)
+                .withField("ids", MAP.ofTypes(STRING, MAP.ofTypes(STRING, INTEGER)), EmptyNestedMap::ids);
+
+        Map<String, Map<String, Integer>> ids = new HashMap<>();
+        ids.put("key", null);
+        var rec = new EmptyNestedMap("foo", ids);
+        var writerTest = new ParquetWriterTest<>(EmptyNestedMap.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        EmptyNestedMap expectedEmptyMap = new EmptyNestedMap("foo", ids);
+        assertEquals(expectedEmptyMap, carpetReader.read());
+    }
+
+    @Test
+    void emptyNestedListIsSupported() throws IOException {
+
+        record EmptyNestedCollection(String name, Map<String, List<String>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedCollection.class)
+                .withField("name", STRING, EmptyNestedCollection::name)
+                .withField("ids", MAP.ofTypes(STRING, LIST.ofType(STRING)), EmptyNestedCollection::ids);
+
+        var rec = new EmptyNestedCollection("foo", Map.of("key", List.of()));
+        var writerTest = new ParquetWriterTest<>(EmptyNestedCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void nullNestedListIsSupported() throws IOException {
+
+        record EmptyNestedCollection(String name, Map<String, List<String>> ids) {
+        }
+
+        var mapper = writeRecordModel(EmptyNestedCollection.class)
+                .withField("name", STRING, EmptyNestedCollection::name)
+                .withField("ids", MAP.ofTypes(STRING, LIST.ofType(STRING)), EmptyNestedCollection::ids);
+
+        Map<String, List<String>> nullValue = new HashMap<>();
+        nullValue.put("key", null);
+        var rec = new EmptyNestedCollection("foo", nullValue);
+        var writerTest = new ParquetWriterTest<>(EmptyNestedCollection.class);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    // Map.of doesn't support null values
+    private <T, R> Map<T, R> mapOf(T key1, R value1, T key2, R value2) {
+        HashMap<T, R> map = new HashMap<>();
+        map.put(key1, value1);
+        map.put(key2, value2);
+        return map;
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
@@ -1,0 +1,1757 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.writer;
+
+import static com.jerolba.carpet.ColumnNamingStrategy.SNAKE_CASE;
+import static com.jerolba.carpet.model.FieldTypes.BIG_DECIMAL;
+import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
+import static com.jerolba.carpet.model.FieldTypes.BYTE;
+import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.ENUM;
+import static com.jerolba.carpet.model.FieldTypes.FLOAT;
+import static com.jerolba.carpet.model.FieldTypes.INSTANT;
+import static com.jerolba.carpet.model.FieldTypes.INTEGER;
+import static com.jerolba.carpet.model.FieldTypes.LIST;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_DATE;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_DATE_TIME;
+import static com.jerolba.carpet.model.FieldTypes.LOCAL_TIME;
+import static com.jerolba.carpet.model.FieldTypes.LONG;
+import static com.jerolba.carpet.model.FieldTypes.SHORT;
+import static com.jerolba.carpet.model.FieldTypes.STRING;
+import static com.jerolba.carpet.model.FieldTypes.writeRecordModel;
+import static java.time.ZoneOffset.ofHours;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.avro.Conversions.DecimalConversion;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.jerolba.carpet.ParquetWriterTest;
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.model.FieldTypes;
+import com.jerolba.carpet.model.WriteRecordModelType;
+
+class WriteRecordModelWriterTest {
+
+    enum Category {
+        one, two, three;
+    }
+
+    @Nested
+    class SimpleTypes {
+
+        @Test
+        void intPrimitive() throws IOException {
+
+            record IntPrimitive(int value) {
+            }
+
+            var mapper = writeRecordModel(IntPrimitive.class)
+                    .withField("value", IntPrimitive::value);
+
+            var rec1 = new IntPrimitive(1);
+            var rec2 = new IntPrimitive(2);
+            var writerTest = new ParquetWriterTest<>(IntPrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void longPrimitive() throws IOException {
+
+            record LongPrimitive(long value) {
+            }
+
+            var mapper = writeRecordModel(LongPrimitive.class)
+                    .withField("value", LongPrimitive::value);
+
+            var rec1 = new LongPrimitive(191919191919L);
+            var rec2 = new LongPrimitive(292929292929L);
+            var writerTest = new ParquetWriterTest<>(LongPrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void doublePrimitive() throws IOException {
+
+            record DoublePrimitive(double value) {
+            }
+
+            var mapper = writeRecordModel(DoublePrimitive.class)
+                    .withField("value", DoublePrimitive::value);
+
+            var rec1 = new DoublePrimitive(1.9);
+            var rec2 = new DoublePrimitive(2.9);
+            var writerTest = new ParquetWriterTest<>(DoublePrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void floatPrimitive() throws IOException {
+
+            record FloatPrimitive(float value) {
+            }
+
+            var mapper = writeRecordModel(FloatPrimitive.class)
+                    .withField("value", FloatPrimitive::value);
+
+            var rec1 = new FloatPrimitive(1.9f);
+            var rec2 = new FloatPrimitive(2.9f);
+            var writerTest = new ParquetWriterTest<>(FloatPrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void shortPrimitive() throws IOException {
+
+            record ShortPrimitive(short value) {
+            }
+
+            var mapper = writeRecordModel(ShortPrimitive.class)
+                    .withField("value", ShortPrimitive::value);
+
+            var rec1 = new ShortPrimitive((short) 1);
+            var rec2 = new ShortPrimitive((short) 2);
+            var writerTest = new ParquetWriterTest<>(ShortPrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).shortValue());
+            assertEquals(rec2.value, ((Number) avroReader.read().get("value")).shortValue());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void bytePrimitive() throws IOException {
+
+            record BytePrimitive(byte value) {
+            }
+
+            var mapper = writeRecordModel(BytePrimitive.class)
+                    .withField("value", BytePrimitive::value);
+
+            var rec1 = new BytePrimitive((byte) 1);
+            var rec2 = new BytePrimitive((byte) 2);
+            var writerTest = new ParquetWriterTest<>(BytePrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).byteValue());
+            assertEquals(rec2.value, ((Number) avroReader.read().get("value")).byteValue());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void booleanPrimitive() throws IOException {
+
+            record BooleanPrimitive(boolean value) {
+            }
+
+            var mapper = writeRecordModel(BooleanPrimitive.class)
+                    .withField("value", BooleanPrimitive::value);
+
+            var rec1 = new BooleanPrimitive(true);
+            var rec2 = new BooleanPrimitive(false);
+            var writerTest = new ParquetWriterTest<>(BooleanPrimitive.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void integerObject() throws IOException {
+
+            record IntegerObject(Integer value) {
+            }
+
+            var mapper = writeRecordModel(IntegerObject.class)
+                    .withField("value", INTEGER, IntegerObject::value);
+
+            var rec1 = new IntegerObject(1);
+            var rec2 = new IntegerObject(2);
+            var writerTest = new ParquetWriterTest<>(IntegerObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void longObject() throws IOException {
+
+            record LongObject(Long value) {
+            }
+
+            var mapper = writeRecordModel(LongObject.class)
+                    .withField("value", LONG, LongObject::value);
+
+            var rec1 = new LongObject(191919191919L);
+            var rec2 = new LongObject(292929292929L);
+            var writerTest = new ParquetWriterTest<>(LongObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void doubleObject() throws IOException {
+
+            record DoubleObject(Double value) {
+            }
+
+            var mapper = writeRecordModel(DoubleObject.class)
+                    .withField("value", DOUBLE, DoubleObject::value);
+
+            var rec1 = new DoubleObject(1.9);
+            var rec2 = new DoubleObject(2.9);
+            var writerTest = new ParquetWriterTest<>(DoubleObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void floatObject() throws IOException {
+
+            record FloatObject(Float value) {
+            }
+
+            var mapper = writeRecordModel(FloatObject.class)
+                    .withField("value", FLOAT, FloatObject::value);
+
+            var rec1 = new FloatObject(1.9f);
+            var rec2 = new FloatObject(2.9f);
+            var writerTest = new ParquetWriterTest<>(FloatObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void shortObject() throws IOException {
+
+            record ShortObject(Short value) {
+            }
+
+            var mapper = writeRecordModel(ShortObject.class)
+                    .withField("value", SHORT, ShortObject::value);
+
+            var rec1 = new ShortObject((short) 1);
+            var rec2 = new ShortObject((short) 2);
+            var writerTest = new ParquetWriterTest<>(ShortObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).shortValue());
+            assertEquals(rec2.value, ((Number) avroReader.read().get("value")).shortValue());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void byteObject() throws IOException {
+
+            record ByteObject(Byte value) {
+            }
+
+            var mapper = writeRecordModel(ByteObject.class)
+                    .withField("value", BYTE, ByteObject::value);
+
+            var rec1 = new ByteObject((byte) 1);
+            var rec2 = new ByteObject((byte) 2);
+            var writerTest = new ParquetWriterTest<>(ByteObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).byteValue());
+            assertEquals(rec2.value, ((Number) avroReader.read().get("value")).byteValue());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void booleanObject() throws IOException {
+
+            record BooleanObject(Boolean value) {
+            }
+
+            var mapper = writeRecordModel(BooleanObject.class)
+                    .withField("value", BOOLEAN, BooleanObject::value);
+
+            var rec1 = new BooleanObject(true);
+            var rec2 = new BooleanObject(false);
+            var writerTest = new ParquetWriterTest<>(BooleanObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertEquals(rec2.value, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void stringObject() throws IOException {
+
+            record StringObject(String value) {
+            }
+
+            var mapper = writeRecordModel(StringObject.class)
+                    .withField("value", STRING, StringObject::value);
+
+            var rec1 = new StringObject("Madrid");
+            var rec2 = new StringObject("Zaragoza");
+            var writerTest = new ParquetWriterTest<>(StringObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value").toString());
+            assertEquals(rec2.value, avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void enumObject() throws IOException {
+
+            record EnumObject(Category value) {
+            }
+
+            var mapper = writeRecordModel(EnumObject.class)
+                    .withField("value", ENUM.ofType(Category.class), EnumObject::value);
+
+            var rec1 = new EnumObject(Category.one);
+            var rec2 = new EnumObject(Category.two);
+            var writerTest = new ParquetWriterTest<>(EnumObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.name(), avroReader.read().get("value").toString());
+            assertEquals(rec2.value.name(), avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void uuidObject() throws IOException {
+
+            record UuidObject(UUID value) {
+            }
+
+            var mapper = writeRecordModel(UuidObject.class)
+                    .withField("value", FieldTypes.UUID, UuidObject::value);
+
+            var rec1 = new UuidObject(UUID.randomUUID());
+            var rec2 = new UuidObject(UUID.randomUUID());
+            var writerTest = new ParquetWriterTest<>(UuidObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.toString(), avroReader.read().get("value").toString());
+            assertEquals(rec2.value.toString(), avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Nested
+        class BigDecimalField {
+
+            record BigDecimalObject(BigDecimal value) {
+            }
+
+            private final WriteRecordModelType<BigDecimalObject> mapper = writeRecordModel(BigDecimalObject.class)
+                    .withField("value", BIG_DECIMAL, BigDecimalObject::value);
+
+            @Test
+            void highPrecision() throws IOException {
+                var bigDec1 = new BigDecimal("12345678901234.56789");
+                var bigDec2 = new BigDecimal("98765432109876.54321");
+                var rec1 = new BigDecimalObject(bigDec1);
+                var rec2 = new BigDecimalObject(bigDec2);
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(20, 5);
+                writerTest.write(mapper, rec1, rec2);
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new DecimalConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+
+                assertEquals(bigDec1, avroReader.read().get("value"));
+                assertEquals(bigDec2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void mediumPrecision() throws IOException {
+                var bigDec1 = new BigDecimal("1234567890123.456");
+                var bigDec2 = new BigDecimal("9876543210987.654");
+                var rec1 = new BigDecimalObject(bigDec1);
+                var rec2 = new BigDecimalObject(bigDec2);
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(18, 3);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void lowPrecision() throws IOException {
+                var bigDec1 = new BigDecimal("12345.6789");
+                var bigDec2 = new BigDecimal("98765.4321");
+                var rec1 = new BigDecimalObject(bigDec1);
+                var rec2 = new BigDecimalObject(bigDec2);
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(9, 4);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void rescaling() throws IOException {
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(20, 5);
+                writerTest.write(mapper,
+                        new BigDecimalObject(new BigDecimal("12345678901234.5")),
+                        new BigDecimalObject(new BigDecimal("98765432109876.5")));
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new DecimalConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+
+                BigDecimal scaled1 = new BigDecimal("12345678901234.50000");
+                BigDecimal scaled2 = new BigDecimal("98765432109876.50000");
+                assertEquals(scaled1, avroReader.read().get("value"));
+                assertEquals(scaled2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(scaled1, carpetReader.read().value());
+                assertEquals(scaled2, carpetReader.read().value());
+            }
+
+            @Test
+            void invalidRescaling() {
+                var rec1 = new BigDecimalObject(new BigDecimal("12345678901234.5678"));
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(20, 2);
+                assertThrowsExactly(RecordTypeConversionException.class,
+                        () -> writerTest.write(mapper, rec1));
+            }
+
+            @Test
+            void invalidPrecision() {
+                var rec1 = new BigDecimalObject(new BigDecimal("12345678901234.5678"));
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withDecimalConfig(10, 4);
+                assertThrowsExactly(RecordTypeConversionException.class,
+                        () -> writerTest.write(mapper, rec1));
+            }
+
+            @Test
+            void allowScaleAdjustament() throws IOException {
+                var writerTest = new ParquetWriterTest<>(BigDecimalObject.class)
+                        .withBigDecimalScaleAdjustment(RoundingMode.HALF_UP)
+                        .withDecimalConfig(20, 2);
+                writerTest.write(mapper,
+                        new BigDecimalObject(new BigDecimal("12345678901234.5678")),
+                        new BigDecimalObject(new BigDecimal("12345678901234.1234")));
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new DecimalConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+
+                BigDecimal scaled1 = new BigDecimal("12345678901234.57");
+                BigDecimal scaled2 = new BigDecimal("12345678901234.12");
+                assertEquals(scaled1, avroReader.read().get("value"));
+                assertEquals(scaled2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(scaled1, carpetReader.read().value());
+                assertEquals(scaled2, carpetReader.read().value());
+            }
+
+        }
+
+        @Test
+        void integerNullObject() throws IOException {
+
+            record IntegerNullObject(Integer value) {
+            }
+
+            var mapper = writeRecordModel(IntegerNullObject.class)
+                    .withField("value", INTEGER, IntegerNullObject::value);
+
+            var rec1 = new IntegerNullObject(1);
+            var rec2 = new IntegerNullObject(null);
+            var writerTest = new ParquetWriterTest<>(IntegerNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void longNullObject() throws IOException {
+
+            record LongNullObject(Long value) {
+            }
+
+            var mapper = writeRecordModel(LongNullObject.class)
+                    .withField("value", LONG, LongNullObject::value);
+
+            var rec1 = new LongNullObject(191919191919L);
+            var rec2 = new LongNullObject(null);
+            var writerTest = new ParquetWriterTest<>(LongNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void doubleNullObject() throws IOException {
+
+            record DoubleNullObject(Double value) {
+            }
+
+            var mapper = writeRecordModel(DoubleNullObject.class)
+                    .withField("value", DOUBLE, DoubleNullObject::value);
+
+            var rec1 = new DoubleNullObject(1.9);
+            var rec2 = new DoubleNullObject(null);
+            var writerTest = new ParquetWriterTest<>(DoubleNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void floatNullObject() throws IOException {
+
+            record FloatNullObject(Float value) {
+            }
+
+            var mapper = writeRecordModel(FloatNullObject.class)
+                    .withField("value", FLOAT, FloatNullObject::value);
+
+            var rec1 = new FloatNullObject(1.9f);
+            var rec2 = new FloatNullObject(null);
+            var writerTest = new ParquetWriterTest<>(FloatNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void shortNullObject() throws IOException {
+
+            record ShortNullObject(Short value) {
+            }
+
+            var mapper = writeRecordModel(ShortNullObject.class)
+                    .withField("value", SHORT, ShortNullObject::value);
+
+            var rec1 = new ShortNullObject((short) 1);
+            var rec2 = new ShortNullObject(null);
+            var writerTest = new ParquetWriterTest<>(ShortNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).shortValue());
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void byteNullObject() throws IOException {
+
+            record ByteNullObject(Byte value) {
+            }
+
+            var mapper = writeRecordModel(ByteNullObject.class)
+                    .withField("value", BYTE, ByteNullObject::value);
+
+            var rec1 = new ByteNullObject((byte) 1);
+            var rec2 = new ByteNullObject(null);
+            var writerTest = new ParquetWriterTest<>(ByteNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, ((Number) avroReader.read().get("value")).byteValue());
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void booleanNullObject() throws IOException {
+
+            record BooleanNullObject(Boolean value) {
+            }
+
+            var mapper = writeRecordModel(BooleanNullObject.class)
+                    .withField("value", BOOLEAN, BooleanNullObject::value);
+
+            var rec1 = new BooleanNullObject(true);
+            var rec2 = new BooleanNullObject(null);
+            var writerTest = new ParquetWriterTest<>(BooleanNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value"));
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void stringNullObject() throws IOException {
+
+            record StringNullObject(String value) {
+            }
+
+            var mapper = writeRecordModel(StringNullObject.class)
+                    .withField("value", STRING, StringNullObject::value);
+
+            var rec1 = new StringNullObject("Madrid");
+            var rec2 = new StringNullObject(null);
+            var writerTest = new ParquetWriterTest<>(StringNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value, avroReader.read().get("value").toString());
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void enumNullObject() throws IOException {
+
+            record EnumNullObject(Category value) {
+            }
+
+            var mapper = writeRecordModel(EnumNullObject.class)
+                    .withField("value", ENUM.ofType(Category.class), EnumNullObject::value);
+
+            var rec1 = new EnumNullObject(Category.one);
+            var rec2 = new EnumNullObject(null);
+            var writerTest = new ParquetWriterTest<>(EnumNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.name(), avroReader.read().get("value").toString());
+            assertNull(avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void uuidNullObject() throws IOException {
+
+            record UuidNullObject(UUID value) {
+            }
+
+            var mapper = writeRecordModel(UuidNullObject.class)
+                    .withField("value", FieldTypes.UUID, UuidNullObject::value);
+
+            var rec1 = new UuidNullObject(UUID.randomUUID());
+            var rec2 = new UuidNullObject(null);
+            var writerTest = new ParquetWriterTest<>(UuidNullObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.toString(), avroReader.read().get("value").toString());
+            assertEquals(null, avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+    }
+
+    @Nested
+    class DateTypes {
+
+        @Test
+        void localDate() throws IOException {
+
+            record LocalDateRecord(LocalDate value) {
+            }
+
+            var mapper = writeRecordModel(LocalDateRecord.class)
+                    .withField("value", LOCAL_DATE, LocalDateRecord::value);
+
+            var rec1 = new LocalDateRecord(LocalDate.of(2022, 11, 21));
+            var rec2 = new LocalDateRecord(LocalDate.of(1976, 1, 15));
+            var writerTest = new ParquetWriterTest<>(LocalDateRecord.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals((int) rec1.value.toEpochDay(), avroReader.read().get("value"));
+            assertEquals((int) rec2.value.toEpochDay(), avroReader.read().get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Nested
+        class LocalTimeType {
+
+            record LocalTimeRecord(LocalTime value) {
+            }
+
+            private final WriteRecordModelType<LocalTimeRecord> mapper = writeRecordModel(LocalTimeRecord.class)
+                    .withField("value", LOCAL_TIME, LocalTimeRecord::value);
+
+            LocalTimeRecord rec1 = new LocalTimeRecord(LocalTime.of(9, 30, 21, 100200300));
+            LocalTimeRecord rec2 = new LocalTimeRecord(LocalTime.of(23, 59, 59, 999999999));
+
+            @Test
+            void timeMillis() throws IOException {
+
+                var writerTest = new ParquetWriterTest<>(LocalTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MILLIS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals((int) (rec1.value.toNanoOfDay() / 1000000), avroReader.read().get("value"));
+                assertEquals((int) (rec2.value.toNanoOfDay() / 1000000), avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(LocalTime.of(9, 30, 21, 100000000), carpetReader.read().value());
+                assertEquals(LocalTime.of(23, 59, 59, 999000000), carpetReader.read().value());
+            }
+
+            @Test
+            void timeMicros() throws IOException {
+
+                var writerTest = new ParquetWriterTest<>(LocalTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MICROS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals(rec1.value.toNanoOfDay() / 1000, avroReader.read().get("value"));
+                assertEquals(rec2.value.toNanoOfDay() / 1000, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(LocalTime.of(9, 30, 21, 100200000), carpetReader.read().value());
+                assertEquals(LocalTime.of(23, 59, 59, 999999000), carpetReader.read().value());
+            }
+
+            @Test
+            void timeNanos() throws IOException {
+
+                var writerTest = new ParquetWriterTest<>(LocalTimeRecord.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals(rec1.value.toNanoOfDay(), avroReader.read().get("value"));
+                assertEquals(rec2.value.toNanoOfDay(), avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+        }
+
+        @Nested
+        class InstantType {
+
+            record InstantRecord(Instant value) {
+            }
+
+            private final WriteRecordModelType<InstantRecord> mapper = writeRecordModel(InstantRecord.class)
+                    .withField("value", INSTANT, InstantRecord::value);
+
+            private final LocalDateTime local = LocalDateTime.of(2024, 5, 3, 15, 31, 11);
+            private final Instant instant1 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(2)), 987654321);
+            private final Instant instant2 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(-2)), 123456789);
+            private final InstantRecord rec1 = new InstantRecord(instant1);
+            private final InstantRecord rec2 = new InstantRecord(instant2);
+
+            @Test
+            void millis() throws IOException {
+                var writerTest = new ParquetWriterTest<>(InstantRecord.class)
+                        .withTimeUnit(TimeUnit.MILLIS);
+                writerTest.write(mapper, rec1, rec2);
+
+                Instant expected1 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(2)), 987000000);
+                Instant expected2 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(-2)), 123000000);
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+                assertEquals(expected1, avroReader.read().get("value"));
+                assertEquals(expected2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            void micros() throws IOException {
+                var writerTest = new ParquetWriterTest<>(InstantRecord.class)
+                        .withTimeUnit(TimeUnit.MICROS);
+                writerTest.write(mapper, rec1, rec2);
+
+                Instant expected1 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(2)), 987654000);
+                Instant expected2 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(-2)), 123456000);
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+                assertEquals(expected1, avroReader.read().get("value"));
+                assertEquals(expected2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            void nanos() throws IOException {
+                var writerTest = new ParquetWriterTest<>(InstantRecord.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                Instant expected1 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(2)), 987654321);
+                Instant expected2 = Instant.ofEpochSecond(local.toEpochSecond(ofHours(-2)), 123456789);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+        }
+
+        @Nested
+        class LocalDateTimeType {
+
+            record LocalDateTimeRecord(LocalDateTime value) {
+            }
+
+            private final WriteRecordModelType<LocalDateTimeRecord> mapper = writeRecordModel(LocalDateTimeRecord.class)
+                    .withField("value", LOCAL_DATE_TIME, LocalDateTimeRecord::value);
+
+            private final LocalDateTime local1 = LocalDateTime.of(2024, 5, 3, 15, 31, 11, 987654321);
+            private final LocalDateTime local2 = LocalDateTime.of(2024, 5, 3, 23, 59, 59, 123456789);
+            private final LocalDateTimeRecord rec1 = new LocalDateTimeRecord(local1);
+            private final LocalDateTimeRecord rec2 = new LocalDateTimeRecord(local2);
+
+            @Test
+            @Disabled("Waiting for 1.14.0 release")
+            void millis() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MILLIS);
+                writerTest.write(mapper, rec1, rec2);
+
+                LocalDateTime expected1 = LocalDateTime.of(2024, 5, 3, 15, 31, 11, 987000000);
+                LocalDateTime expected2 = LocalDateTime.of(2024, 5, 3, 23, 59, 59, 123000000);
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+                assertEquals(expected1, avroReader.read().get("value"));
+                assertEquals(expected2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            // Remove after 1.14.0 release
+            void millisByLong() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MILLIS);
+                writerTest.write(mapper, rec1, rec2);
+
+                LocalDateTime expected1 = LocalDateTime.of(2024, 5, 3, 15, 31, 11, 987000000);
+                LocalDateTime expected2 = LocalDateTime.of(2024, 5, 3, 23, 59, 59, 123000000);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals(expected1.toEpochSecond(ZoneOffset.UTC) * 1000 + 987, avroReader.read().get("value"));
+                assertEquals(expected2.toEpochSecond(ZoneOffset.UTC) * 1000 + 123, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            @Disabled("Waiting for 1.14.0 release")
+            void micros() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MICROS);
+                writerTest.write(mapper, rec1, rec2);
+
+                LocalDateTime expected1 = LocalDateTime.of(2024, 5, 3, 15, 31, 11, 987654000);
+                LocalDateTime expected2 = LocalDateTime.of(2024, 5, 3, 23, 59, 59, 123456000);
+
+                GenericData genericDataModel = new GenericData();
+                genericDataModel.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+                var avroReader = writerTest.getAvroGenericRecordReaderWithModel(genericDataModel);
+                assertEquals(expected1, avroReader.read().get("value"));
+                assertEquals(expected2, avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            // Remove after 1.14.0 release
+            void microsByLong() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeRecord.class)
+                        .withTimeUnit(TimeUnit.MICROS);
+                writerTest.write(mapper, rec1, rec2);
+
+                LocalDateTime expected1 = LocalDateTime.of(2024, 5, 3, 15, 31, 11, 987654000);
+                LocalDateTime expected2 = LocalDateTime.of(2024, 5, 3, 23, 59, 59, 123456000);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals(expected1.toEpochSecond(ZoneOffset.UTC) * 1_000_000 + 987654,
+                        avroReader.read().get("value"));
+                assertEquals(expected2.toEpochSecond(ZoneOffset.UTC) * 1_000_000 + 123456,
+                        avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(expected1, carpetReader.read().value());
+                assertEquals(expected2, carpetReader.read().value());
+            }
+
+            @Test
+            void nanos() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeRecord.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var avroReader = writerTest.getAvroGenericRecordReader();
+                assertEquals(local1.toEpochSecond(ZoneOffset.UTC) * 1_000_000_000 + 987654321,
+                        avroReader.read().get("value"));
+                assertEquals(local2.toEpochSecond(ZoneOffset.UTC) * 1_000_000_000 + 123456789,
+                        avroReader.read().get("value"));
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(local1, carpetReader.read().value());
+                assertEquals(local2, carpetReader.read().value());
+            }
+        }
+    }
+
+    @Nested
+    class InListTypes {
+
+        @Test
+        void integerList() throws IOException {
+
+            record IntegerList(List<Integer> values) {
+            }
+
+            var mapper = writeRecordModel(IntegerList.class)
+                    .withField("values", LIST.ofType(INTEGER), IntegerList::values);
+
+            var rec1 = new IntegerList(asList(1, null, 3));
+            var rec2 = new IntegerList(null);
+            var writerTest = new ParquetWriterTest<>(IntegerList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void longList() throws IOException {
+
+            record LongList(List<Long> values) {
+            }
+
+            var mapper = writeRecordModel(LongList.class)
+                    .withField("values", LIST.ofType(LONG), LongList::values);
+
+            var rec1 = new LongList(asList(191919191919L, null, 28282L));
+            var rec2 = new LongList(null);
+            var writerTest = new ParquetWriterTest<>(LongList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void doubleList() throws IOException {
+
+            record DoubleList(List<Double> values) {
+            }
+
+            var mapper = writeRecordModel(DoubleList.class)
+                    .withField("values", LIST.ofType(DOUBLE), DoubleList::values);
+
+            var rec1 = new DoubleList(asList(1.9, null, 2.9));
+            var rec2 = new DoubleList(null);
+            var writerTest = new ParquetWriterTest<>(DoubleList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void floatList() throws IOException {
+
+            record FloatList(List<Float> values) {
+            }
+
+            var mapper = writeRecordModel(FloatList.class)
+                    .withField("values", LIST.ofType(FLOAT), FloatList::values);
+
+            var rec1 = new FloatList(asList(1.9f, null, 2.9f));
+            var rec2 = new FloatList(null);
+            var writerTest = new ParquetWriterTest<>(FloatList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void shortList() throws IOException {
+
+            record ShortList(List<Short> values) {
+            }
+
+            var mapper = writeRecordModel(ShortList.class)
+                    .withField("values", LIST.ofType(SHORT), ShortList::values);
+
+            var rec1 = new ShortList(asList((short) 1, null, (short) 3));
+            var rec2 = new ShortList(null);
+            var writerTest = new ParquetWriterTest<>(ShortList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void byteList() throws IOException {
+
+            record ByteList(List<Byte> values) {
+            }
+
+            var mapper = writeRecordModel(ByteList.class)
+                    .withField("values", LIST.ofType(BYTE), ByteList::values);
+
+            var rec1 = new ByteList(asList((byte) 1, null, (byte) 3));
+            var rec2 = new ByteList(null);
+            var writerTest = new ParquetWriterTest<>(ByteList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void booleanList() throws IOException {
+
+            record BooleanList(List<Boolean> values) {
+            }
+
+            var mapper = writeRecordModel(BooleanList.class)
+                    .withField("values", LIST.ofType(BOOLEAN), BooleanList::values);
+
+            var rec1 = new BooleanList(asList(true, null, false));
+            var rec2 = new BooleanList(null);
+            var writerTest = new ParquetWriterTest<>(BooleanList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void stringList() throws IOException {
+
+            record StringList(List<String> values) {
+            }
+
+            var mapper = writeRecordModel(StringList.class)
+                    .withField("values", LIST.ofType(STRING), StringList::values);
+
+            var rec1 = new StringList(asList("Madrid", null, "Zaragoza"));
+            var rec2 = new StringList(null);
+            var writerTest = new ParquetWriterTest<>(StringList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void enumList() throws IOException {
+
+            record EnumList(List<Category> values) {
+            }
+
+            var mapper = writeRecordModel(EnumList.class)
+                    .withField("values", LIST.ofType(ENUM.ofType(Category.class)), EnumList::values);
+
+            var rec1 = new EnumList(asList(Category.one, null, Category.two));
+            var rec2 = new EnumList(null);
+            var writerTest = new ParquetWriterTest<>(EnumList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void uuidList() throws IOException {
+
+            record UuidList(List<UUID> values) {
+            }
+
+            var mapper = writeRecordModel(UuidList.class)
+                    .withField("values", LIST.ofType(FieldTypes.UUID), UuidList::values);
+
+            var rec1 = new UuidList(asList(UUID.randomUUID(), null, UUID.randomUUID()));
+            var rec2 = new UuidList(null);
+            var writerTest = new ParquetWriterTest<>(UuidList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void localDateList() throws IOException {
+
+            record LocalDateList(List<LocalDate> values) {
+            }
+
+            var mapper = writeRecordModel(LocalDateList.class)
+                    .withField("values", LIST.ofType(LOCAL_DATE), LocalDateList::values);
+
+            var rec1 = new LocalDateList(asList(LocalDate.of(2024, 1, 30), null, LocalDate.of(2024, 2, 20)));
+            var rec2 = new LocalDateList(null);
+            var writerTest = new ParquetWriterTest<>(LocalDateList.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Nested
+        class LocalTimeListWrite {
+
+            record LocalTimeList(List<LocalTime> values) {
+            }
+
+            WriteRecordModelType<LocalTimeList> mapper = writeRecordModel(LocalTimeList.class)
+                    .withField("values", LIST.ofType(LOCAL_TIME), LocalTimeList::values);
+
+            LocalTimeList rec1 = new LocalTimeList(
+                    asList(LocalTime.of(8, 10, 23, 123456789), null, LocalTime.of(10, 0, 0, 0)));
+            LocalTimeList rec2 = new LocalTimeList(null);
+
+            @Test
+            void localTimeMillisList() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalTimeList.class)
+                        .withTimeUnit(TimeUnit.MILLIS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                LocalTimeList read1 = carpetReader.read();
+                assertEquals(LocalTime.of(8, 10, 23, 123000000), read1.values.get(0));
+                assertNull(read1.values.get(1));
+                assertEquals(LocalTime.of(10, 0, 0, 0), read1.values.get(2));
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void localTimeMicrosList() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalTimeList.class)
+                        .withTimeUnit(TimeUnit.MICROS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                LocalTimeList read1 = carpetReader.read();
+                assertEquals(LocalTime.of(8, 10, 23, 123456000), read1.values.get(0));
+                assertNull(read1.values.get(1));
+                assertEquals(LocalTime.of(10, 0, 0, 0), read1.values.get(2));
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void localTimeNanosList() throws IOException {
+                var writerTest = new ParquetWriterTest<>(LocalTimeList.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+        }
+
+        @Nested
+        class TimeStampListWrite {
+
+            @Test
+            void localDateTimeList() throws IOException {
+
+                record LocalDateTimeList(List<LocalDateTime> values) {
+                }
+
+                var mapper = writeRecordModel(LocalDateTimeList.class)
+                        .withField("values", LIST.ofType(LOCAL_DATE_TIME), LocalDateTimeList::values);
+
+                LocalDateTimeList rec1 = new LocalDateTimeList(
+                        asList(LocalDateTime.of(2024, 5, 3, 8, 10, 23, 123456789), null,
+                                LocalDateTime.of(1976, 1, 15, 10, 0, 0, 0)));
+                LocalDateTimeList rec2 = new LocalDateTimeList(null);
+
+                var writerTest = new ParquetWriterTest<>(LocalDateTimeList.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+
+            @Test
+            void intantList() throws IOException {
+
+                record InstantList(List<Instant> values) {
+                }
+
+                var mapper = writeRecordModel(InstantList.class)
+                        .withField("values", LIST.ofType(INSTANT), InstantList::values);
+
+                InstantList rec1 = new InstantList(asList(
+                        LocalDateTime.of(2024, 5, 3, 8, 10, 23, 123456789).toInstant(ZoneOffset.ofHours(3)), null,
+                        LocalDateTime.of(1976, 1, 15, 10, 0, 0, 0).toInstant(ZoneOffset.ofHours(2))));
+                InstantList rec2 = new InstantList(null);
+
+                var writerTest = new ParquetWriterTest<>(InstantList.class)
+                        .withTimeUnit(TimeUnit.NANOS);
+                writerTest.write(mapper, rec1, rec2);
+
+                var carpetReader = writerTest.getCarpetReader();
+                assertEquals(rec1, carpetReader.read());
+                assertEquals(rec2, carpetReader.read());
+            }
+        }
+
+        @Test
+        void bigDecimalList() throws IOException {
+
+            record BigDecimalList(List<BigDecimal> values) {
+            }
+
+            var mapper = writeRecordModel(BigDecimalList.class)
+                    .withField("values", LIST.ofType(BIG_DECIMAL), BigDecimalList::values);
+
+            var rec1 = new BigDecimalList(asList(new BigDecimal("1234567.123"), null, BigDecimal.TEN));
+            var rec2 = new BigDecimalList(null);
+            var writerTest = new ParquetWriterTest<>(BigDecimalList.class)
+                    .withDecimalConfig(20, 3);
+            writerTest.write(mapper, rec1, rec2);
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(new BigDecimalList(asList(new BigDecimal("1234567.123"), null, new BigDecimal("10.000"))),
+                    carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+    }
+
+    @Test
+    void emptyFile() throws IOException {
+
+        record EmptyFile(String someValue) {
+        }
+
+        var mapper = writeRecordModel(EmptyFile.class)
+                .withField("someValue", STRING, EmptyFile::someValue);
+
+        var writerTest = new ParquetWriterTest<>(EmptyFile.class);
+        writerTest.write(mapper);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        assertNull(avroReader.read());
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertNull(carpetReader.read());
+    }
+
+    @Test
+    void classWithMultipleFields() throws IOException {
+
+        record ClassWithMultipleFields(String name, Category category,
+                int p1, Integer f1, long p2, Long f2, double p3, Double f3, float p4, Float f4,
+                byte p5, Byte f5, short p6, Short f6, boolean p7, Boolean f7) {
+        }
+
+        var mapper = writeRecordModel(ClassWithMultipleFields.class)
+                .withField("name", STRING, ClassWithMultipleFields::name)
+                .withField("category", ENUM.ofType(Category.class), ClassWithMultipleFields::category)
+                .withField("p1", ClassWithMultipleFields::p1)
+                .withField("f1", INTEGER, ClassWithMultipleFields::f1)
+                .withField("p2", ClassWithMultipleFields::p2)
+                .withField("f2", LONG, ClassWithMultipleFields::f2)
+                .withField("p3", ClassWithMultipleFields::p3)
+                .withField("f3", DOUBLE, ClassWithMultipleFields::f3)
+                .withField("p4", ClassWithMultipleFields::p4)
+                .withField("f4", FLOAT, ClassWithMultipleFields::f4)
+                .withField("p5", ClassWithMultipleFields::p5)
+                .withField("f5", BYTE, ClassWithMultipleFields::f5)
+                .withField("p6", ClassWithMultipleFields::p6)
+                .withField("f6", SHORT, ClassWithMultipleFields::f6)
+                .withField("p7", ClassWithMultipleFields::p7)
+                .withField("f7", BOOLEAN, ClassWithMultipleFields::f7);
+
+        var rec = new ClassWithMultipleFields("Apple", Category.one,
+                1, 2, 3L, 4L, 5.1, 6.2, 7.3f, 8.4f,
+                (byte) 9, (byte) 10, (short) 11, (short) 12, true, false);
+
+        var writerTest = new ParquetWriterTest<>(ClassWithMultipleFields.class);
+        writerTest.write(mapper, rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord record = avroReader.read();
+        assertEquals(rec.name, record.get("name").toString());
+        assertEquals(rec.category.name(), record.get("category").toString());
+        assertEquals(rec.p1, record.get("p1"));
+        assertEquals(rec.f1, record.get("f1"));
+        assertEquals(rec.p2, record.get("p2"));
+        assertEquals(rec.f2, record.get("f2"));
+        assertEquals(rec.p3, record.get("p3"));
+        assertEquals(rec.f3, record.get("f3"));
+        assertEquals(rec.p4, record.get("p4"));
+        assertEquals(rec.f4, record.get("f4"));
+        assertEquals(rec.p5, ((Number) record.get("p5")).byteValue());
+        assertEquals(rec.f5, ((Number) record.get("f5")).byteValue());
+        assertEquals(rec.p6, ((Number) record.get("p6")).shortValue());
+        assertEquals(rec.f6, ((Number) record.get("f6")).shortValue());
+        assertEquals(rec.p7, record.get("p7"));
+        assertEquals(rec.f7, record.get("f7"));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void classWithMultipleNullFields() throws IOException {
+
+        record ClassWithMultipleNullFields(String name, Category category,
+                int p1, Integer f1, long p2, Long f2, double p3, Double f3, float p4, Float f4,
+                byte p5, Byte f5, short p6, Short f6, boolean p7, Boolean f7) {
+        }
+
+        var mapper = writeRecordModel(ClassWithMultipleNullFields.class)
+                .withField("name", STRING, ClassWithMultipleNullFields::name)
+                .withField("category", ENUM.ofType(Category.class), ClassWithMultipleNullFields::category)
+                .withField("p1", ClassWithMultipleNullFields::p1)
+                .withField("f1", INTEGER, ClassWithMultipleNullFields::f1)
+                .withField("p2", ClassWithMultipleNullFields::p2)
+                .withField("f2", LONG, ClassWithMultipleNullFields::f2)
+                .withField("p3", ClassWithMultipleNullFields::p3)
+                .withField("f3", DOUBLE, ClassWithMultipleNullFields::f3)
+                .withField("p4", ClassWithMultipleNullFields::p4)
+                .withField("f4", FLOAT, ClassWithMultipleNullFields::f4)
+                .withField("p5", ClassWithMultipleNullFields::p5)
+                .withField("f5", BYTE, ClassWithMultipleNullFields::f5)
+                .withField("p6", ClassWithMultipleNullFields::p6)
+                .withField("f6", SHORT, ClassWithMultipleNullFields::f6)
+                .withField("p7", ClassWithMultipleNullFields::p7)
+                .withField("f7", BOOLEAN, ClassWithMultipleNullFields::f7);
+
+        var rec = new ClassWithMultipleNullFields(null, null,
+                101, null, 103L, null, 105.1, null, 107.3f, null,
+                (byte) 109, null, (short) 1011, null, false, null);
+        var writerTest = new ParquetWriterTest<>(ClassWithMultipleNullFields.class);
+        writerTest.write(mapper, rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord record = avroReader.read();
+        assertNull(record.get("name"));
+        assertNull(record.get("category"));
+        assertEquals(rec.p1, record.get("p1"));
+        assertNull(record.get("f1"));
+        assertEquals(rec.p2, record.get("p2"));
+        assertNull(record.get("f2"));
+        assertEquals(rec.p3, record.get("p3"));
+        assertNull(record.get("f3"));
+        assertEquals(rec.p4, record.get("p4"));
+        assertNull(record.get("f4"));
+        assertEquals(rec.p5, ((Number) record.get("p5")).byteValue());
+        assertNull(record.get("f5"));
+        assertEquals(rec.p6, ((Number) record.get("p6")).shortValue());
+        assertNull(record.get("f6"));
+        assertEquals(rec.p7, record.get("p7"));
+        assertNull(record.get("f7"));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Nested
+    class CompositedClasses {
+
+        @Test
+        void compositeValue() throws IOException {
+
+            record Child(String id, int value) {
+            }
+            record CompositeMain(String name, Child child) {
+            }
+
+            var mapper = writeRecordModel(CompositeMain.class)
+                    .withField("name", STRING, CompositeMain::name)
+                    .withField("child", writeRecordModel(Child.class)
+                            .withField("id", STRING, Child::id)
+                            .withField("value", Child::value), CompositeMain::child);
+
+            CompositeMain rec1 = new CompositeMain("Madrid", new Child("Population", 100));
+            CompositeMain rec2 = new CompositeMain("Santander", new Child("Population", 200));
+
+            var writerTest = new ParquetWriterTest<>(CompositeMain.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            GenericRecord record = avroReader.read();
+            assertEquals(rec1.name, record.get("name").toString());
+            GenericRecord child = (GenericRecord) record.get("child");
+            assertEquals(rec1.child.id, child.get("id").toString());
+            assertEquals(rec1.child.value, child.get("value"));
+            record = avroReader.read();
+            assertEquals(rec2.name, record.get("name").toString());
+            child = (GenericRecord) record.get("child");
+            assertEquals(rec2.child.id, child.get("id").toString());
+            assertEquals(rec2.child.value, child.get("value"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void compositeNullValue() throws IOException {
+
+            record Child(String id, int value) {
+            }
+            record CompositeNullMain(String name, Child child) {
+            }
+
+            var mapper = writeRecordModel(CompositeNullMain.class)
+                    .withField("name", STRING, CompositeNullMain::name)
+                    .withField("child", writeRecordModel(Child.class)
+                            .withField("id", STRING, Child::id)
+                            .withField("value", Child::value), CompositeNullMain::child);
+
+            CompositeNullMain rec1 = new CompositeNullMain("Madrid", new Child("Age", 100));
+            CompositeNullMain rec2 = new CompositeNullMain("Santander", null);
+
+            var writerTest = new ParquetWriterTest<>(CompositeNullMain.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            GenericRecord record = avroReader.read();
+            assertEquals(rec1.name, record.get("name").toString());
+            GenericRecord child = (GenericRecord) record.get("child");
+            assertEquals(rec1.child.id, child.get("id").toString());
+            assertEquals(rec1.child.value, child.get("value"));
+            record = avroReader.read();
+            assertEquals(rec2.name, record.get("name").toString());
+            assertNull(record.get("child"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void multipleLevelComposition() throws IOException {
+
+            record ThirdLevel(String area, long value) {
+            }
+            record SecondLevel(String name, ThirdLevel subChild) {
+            }
+            record MultipleLevelComposition(String id, SecondLevel child) {
+            }
+
+            var modelThirdLevel = writeRecordModel(ThirdLevel.class)
+                    .withField("area", STRING, ThirdLevel::area)
+                    .withField("value", ThirdLevel::value);
+
+            var modelSecondLevel = writeRecordModel(SecondLevel.class)
+                    .withField("name", STRING, SecondLevel::name)
+                    .withField("subChild", modelThirdLevel, SecondLevel::subChild);
+
+            var mapper = writeRecordModel(MultipleLevelComposition.class)
+                    .withField("id", STRING, MultipleLevelComposition::id)
+                    .withField("child", modelSecondLevel, MultipleLevelComposition::child);
+
+            MultipleLevelComposition rec1 = new MultipleLevelComposition("First",
+                    new SecondLevel("Second", new ThirdLevel("Third", 20102032L)));
+            MultipleLevelComposition rec2 = new MultipleLevelComposition("One",
+                    new SecondLevel("Two", null));
+            MultipleLevelComposition rec3 = new MultipleLevelComposition("Uno", null);
+
+            var writerTest = new ParquetWriterTest<>(MultipleLevelComposition.class);
+            writerTest.write(mapper, rec1, rec2, rec3);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            GenericRecord record1 = avroReader.read();
+            assertEquals(rec1.id, record1.get("id").toString());
+            GenericRecord child1 = (GenericRecord) record1.get("child");
+            assertEquals(rec1.child.name, child1.get("name").toString());
+            GenericRecord subChild1 = (GenericRecord) child1.get("subChild");
+            assertEquals(rec1.child.subChild.area, subChild1.get("area").toString());
+            assertEquals(rec1.child.subChild.value, subChild1.get("value"));
+
+            GenericRecord record2 = avroReader.read();
+            assertEquals(rec2.id, record2.get("id").toString());
+            GenericRecord child2 = (GenericRecord) record2.get("child");
+            assertEquals(rec2.child.name, child2.get("name").toString());
+            assertNull(child2.get("subChild"));
+
+            GenericRecord record3 = avroReader.read();
+            assertEquals(rec3.id, record3.get("id").toString());
+            assertNull(record3.get("child"));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+            assertEquals(rec3, carpetReader.read());
+        }
+
+    }
+
+    @Nested
+    class ColumnNameConversion {
+
+        @Test
+        void fieldAliased() throws IOException {
+            record SomeClass(long someId, int operation, boolean active) {
+            }
+
+            var mapper = writeRecordModel(SomeClass.class)
+                    .withField("foo", SomeClass::someId)
+                    .withField("bar", SomeClass::operation)
+                    .withField("enabled", SomeClass::active);
+
+            var writerTest = new ParquetWriterTest<>(SomeClass.class);
+            writerTest.write(mapper, new SomeClass(1L, 2, true));
+
+            String expected = """
+                    message SomeClass {
+                      required int64 foo;
+                      required int32 bar;
+                      required boolean enabled;
+                    }
+                    """;
+            assertEquals(expected, writerTest.getSchema().toString());
+
+            record ReadClass(long foo, int bar, boolean enabled) {
+            }
+            ReadClass value = writerTest.getCarpetReader(ReadClass.class).read();
+            assertEquals(new ReadClass(1L, 2, true), value);
+        }
+
+        @Test
+        void fromCamelCase() throws IOException {
+            record SomeClass(long someId, int operationCode, int with3) {
+            }
+
+            var mapper = writeRecordModel(SomeClass.class)
+                    .withField("some_id", SomeClass::someId)
+                    .withField("operation_code", SomeClass::operationCode)
+                    .withField("with3", SomeClass::with3);
+
+            var writerTest = new ParquetWriterTest<>(SomeClass.class)
+                    .withNameStrategy(SNAKE_CASE);
+            writerTest.write(mapper, new SomeClass(1L, 2, 3));
+
+            String expected = """
+                    message SomeClass {
+                      required int64 some_id;
+                      required int32 operation_code;
+                      required int32 with3;
+                    }
+                    """;
+            assertEquals(expected, writerTest.getSchema().toString());
+
+            record Some_Class(long some_id, int operation_code, int with3) {
+            }
+            Some_Class value = writerTest.getCarpetReader(Some_Class.class).read();
+            assertEquals(new Some_Class(1L, 2, 3), value);
+        }
+
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.jerolba.carpet
-version = 0.2.3
+version = 0.3.0-SNAPSHOT
 
 parquetVersion = 1.15.1
 hadoopVersion = 3.4.1


### PR DESCRIPTION
* Simple DSL to compose entities recursively.
* Can replace existing Java Record to Parquet code using `JavaRecord2WriteModel` 
* Released as experimental feature