### PR TITLE
#68 Add logical type target annotation

### DIFF
--- a/carpet-record/src/main/java/com/jerolba/carpet/CarpetRecordGenerator.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/CarpetRecordGenerator.java
@@ -280,7 +280,8 @@ public class CarpetRecordGenerator {
         LOCAL_TIME_TYPE("LocalTime"),
         LOCAL_DATE_TIME_TYPE("LocalDateTime"),
         INSTANT_TYPE("Instant"),
-        DECIMAL_TYPE("BigDecimal");
+        DECIMAL_TYPE("BigDecimal"),
+        BINARY("Binary");
 
         private final String primitive;
         private final String object;
@@ -307,6 +308,7 @@ public class CarpetRecordGenerator {
                 case FLOAT -> BasicTypes.FLOAT_TYPE;
                 case DOUBLE -> BasicTypes.DOUBLE_TYPE;
                 case BOOLEAN -> BasicTypes.BOOLEAN_TYPE;
+                case BINARY -> BasicTypes.BINARY;
                 default -> throw new RecordTypeConversionException(typeName + " deserialization not supported");
                 };
             }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetBson.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetBson.java
@@ -16,13 +16,14 @@
 package com.jerolba.carpet.annotation;
 
 import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Retention(RUNTIME)
-@Target(RECORD_COMPONENT)
+@Target({ RECORD_COMPONENT, TYPE_USE })
 public @interface ParquetBson {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetBson.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetBson.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.annotation;
+
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(RECORD_COMPONENT)
+public @interface ParquetBson {
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetEnum.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetEnum.java
@@ -16,13 +16,14 @@
 package com.jerolba.carpet.annotation;
 
 import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Retention(RUNTIME)
-@Target(RECORD_COMPONENT)
+@Target({ RECORD_COMPONENT, TYPE_USE })
 public @interface ParquetEnum {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetEnum.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetEnum.java
@@ -13,29 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jerolba.carpet.model;
+package com.jerolba.carpet.annotation;
 
-public record StringType(boolean isNotNull, StringLogicalType logicalType) implements FieldType {
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-    public enum StringLogicalType {
-        JSON, ENUM, STRING;
-    }
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    public StringType notNull() {
-        return new StringType(true, logicalType);
-    }
-
-    public StringType asJson() {
-        return new StringType(isNotNull, StringLogicalType.JSON);
-    }
-
-    public StringType asEnum() {
-        return new StringType(isNotNull, StringLogicalType.ENUM);
-    }
-
-    @Override
-    public Class<String> getClassType() {
-        return String.class;
-    }
+@Retention(RUNTIME)
+@Target(RECORD_COMPONENT)
+public @interface ParquetEnum {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetJson.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetJson.java
@@ -16,13 +16,14 @@
 package com.jerolba.carpet.annotation;
 
 import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Retention(RUNTIME)
-@Target(RECORD_COMPONENT)
+@Target({ RECORD_COMPONENT, TYPE_USE })
 public @interface ParquetJson {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetJson.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetJson.java
@@ -13,25 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jerolba.carpet.model;
+package com.jerolba.carpet.annotation;
 
-public record StringType(boolean isNotNull, StringLogicalType logicalType) implements FieldType {
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-    public enum StringLogicalType {
-        JSON, ENUM, STRING;
-    }
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    public StringType notNull() {
-        return new StringType(true, logicalType);
-    }
-
-    public StringType asJson() {
-        return new StringType(isNotNull, StringLogicalType.JSON);
-    }
-
-    @Override
-    public Class<String> getClassType() {
-        return String.class;
-    }
+@Retention(RUNTIME)
+@Target(RECORD_COMPONENT)
+public @interface ParquetJson {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetString.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/annotation/ParquetString.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jerolba.carpet.model;
+package com.jerolba.carpet.annotation;
 
-public sealed interface FieldType
-        permits BooleanType, ByteType, ShortType, IntegerType,
-        LongType, FloatType, DoubleType, StringType, BinaryType, EnumType,
-        UuidType, BigDecimalType, LocalDateType, LocalTimeType,
-        LocalDateTimeType, InstantType, CollectionType, ListType,
-        SetType, MapType, WriteRecordModelType {
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-    boolean isNotNull();
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-    Class<?> getClassType();
+@Retention(RUNTIME)
+@Target(RECORD_COMPONENT)
+public @interface ParquetString {
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/JavaType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/JavaType.java
@@ -15,22 +15,31 @@
  */
 package com.jerolba.carpet.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.RecordComponent;
 import java.util.Collection;
 import java.util.Map;
+
+import org.apache.parquet.io.api.Binary;
 
 public class JavaType {
 
     private final String typeName;
     private final Class<?> type;
+    private final Annotation[] declaredAnnotations;
 
     public JavaType(RecordComponent recordComponent) {
         this(recordComponent.getType());
     }
 
     public JavaType(Class<?> type) {
+        this(type, null);
+    }
+
+    public JavaType(Class<?> type, Annotation[] declaredAnnotations) {
         this.type = type;
         this.typeName = type.getName();
+        this.declaredAnnotations = declaredAnnotations;
     }
 
     public Class<?> getJavaType() {
@@ -39,6 +48,10 @@ public class JavaType {
 
     public boolean isString() {
         return typeName.equals("java.lang.String");
+    }
+
+    public boolean isBinary() {
+        return Binary.class.isAssignableFrom(type);
     }
 
     public boolean isInteger() {
@@ -111,6 +124,18 @@ public class JavaType {
 
     public boolean isMap() {
         return Map.class.isAssignableFrom(type);
+    }
+
+    public boolean isAnnotatedWith(Class<? extends Annotation> annotationClass) {
+        if (declaredAnnotations == null) {
+            return false;
+        }
+        for (Annotation annotation : declaredAnnotations) {
+            if (annotation.annotationType().equals(annotationClass)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/Parameterized.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/Parameterized.java
@@ -15,6 +15,8 @@
  */
 package com.jerolba.carpet.impl;
 
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
@@ -29,11 +31,15 @@ import com.jerolba.carpet.RecordTypeConversionException;
 public class Parameterized {
 
     public static ParameterizedCollection getParameterizedCollection(RecordComponent attr) {
-        return parametizeTo(attr.getGenericType(), ParameterizedCollection::new);
+        return getParameterizedCollection(attr.getAnnotatedType());
     }
 
     public static ParameterizedCollection getParameterizedCollection(Field attr) {
-        return parametizeTo(attr.getGenericType(), ParameterizedCollection::new);
+        return getParameterizedCollection(attr.getAnnotatedType());
+    }
+
+    public static ParameterizedCollection getParameterizedCollection(AnnotatedType annotatedTypeCollection) {
+        return parametizeTo(annotatedTypeCollection, ParameterizedCollection::new);
     }
 
     public static boolean isCollection(Type type) {
@@ -41,11 +47,15 @@ public class Parameterized {
     }
 
     public static ParameterizedMap getParameterizedMap(RecordComponent attr) {
-        return parametizeTo(attr.getGenericType(), ParameterizedMap::new);
+        return getParameterizedMap(attr.getAnnotatedType());
     }
 
     public static ParameterizedMap getParameterizedMap(Field attr) {
-        return parametizeTo(attr.getGenericType(), ParameterizedMap::new);
+        return getParameterizedMap(attr.getAnnotatedType());
+    }
+
+    public static ParameterizedMap getParameterizedMap(AnnotatedType annotatedTypeMap) {
+        return parametizeTo(annotatedTypeMap, ParameterizedMap::new);
     }
 
     public static boolean isMap(Type type) {
@@ -73,16 +83,15 @@ public class Parameterized {
         return false;
     }
 
-    private static <T> T parametizeTo(java.lang.reflect.Type genericType,
-            BiFunction<Type, ParameterizedType, T> constructor) {
-        if (genericType instanceof TypeVariable<?>) {
-            throw new RecordTypeConversionException(genericType.toString() + " generic types not supported");
+    private static <T> T parametizeTo(AnnotatedType annotatedType,
+            BiFunction<Type, AnnotatedParameterizedType, T> constructor) {
+        if (annotatedType instanceof AnnotatedParameterizedType paramType) {
+            if (paramType.getType() instanceof ParameterizedType rawType) {
+                Type raw = rawType.getRawType();
+                return constructor.apply(raw, paramType);
+            }
         }
-        if (genericType instanceof ParameterizedType paramType) {
-            Type collection = paramType.getRawType();
-            return constructor.apply(collection, paramType);
-        }
-        throw new RecordTypeConversionException("Unsuported type in collection");
+        throw new RecordTypeConversionException("Unsupported type in collection: " + annotatedType);
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedCollection.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedCollection.java
@@ -15,6 +15,7 @@
  */
 package com.jerolba.carpet.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
@@ -35,6 +36,10 @@ public class ParameterizedCollection {
         return Parameterized.getClassFromType(collectionElementType, "in Collection");
     }
 
+    public JavaType getActualJavaType() {
+        return new JavaType(getActualType(), getAnnotations());
+    }
+
     public Class<?> getCollectionType() {
         return (Class<?>) collectionType;
     }
@@ -53,6 +58,10 @@ public class ParameterizedCollection {
 
     public boolean isMap() {
         return Parameterized.isMap(collectionElementType);
+    }
+
+    private Annotation[] getAnnotations() {
+        return annotatedCollectionElementType.getDeclaredAnnotations();
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedCollection.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedCollection.java
@@ -15,17 +15,20 @@
  */
 package com.jerolba.carpet.impl;
 
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 
 public class ParameterizedCollection {
 
     private final Type collectionType;
     private final Type collectionElementType;
+    private final AnnotatedType annotatedCollectionElementType;
 
-    public ParameterizedCollection(Type collectionType, ParameterizedType type) {
+    public ParameterizedCollection(Type collectionType, AnnotatedParameterizedType type) {
         this.collectionType = collectionType;
-        this.collectionElementType = type.getActualTypeArguments()[0];
+        this.annotatedCollectionElementType = type.getAnnotatedActualTypeArguments()[0];
+        this.collectionElementType = annotatedCollectionElementType.getType();
     }
 
     public Class<?> getActualType() {
@@ -37,19 +40,11 @@ public class ParameterizedCollection {
     }
 
     public ParameterizedCollection getParametizedAsCollection() {
-        if (collectionElementType instanceof ParameterizedType paramType) {
-            Type collection = paramType.getRawType();
-            return new ParameterizedCollection(collection, paramType);
-        }
-        return null;
+        return Parameterized.getParameterizedCollection(annotatedCollectionElementType);
     }
 
     public ParameterizedMap getParametizedAsMap() {
-        if (collectionElementType instanceof ParameterizedType paramType) {
-            Type map = paramType.getRawType();
-            return new ParameterizedMap(map, paramType);
-        }
-        return null;
+        return Parameterized.getParameterizedMap(annotatedCollectionElementType);
     }
 
     public boolean isCollection() {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedMap.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedMap.java
@@ -15,6 +15,7 @@
  */
 package com.jerolba.carpet.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
@@ -40,8 +41,24 @@ public class ParameterizedMap {
         return Parameterized.getClassFromType(valueAnnotatedMapElementType.getType(), "in Map value");
     }
 
+    public JavaType getValueActualJavaType() {
+        return new JavaType(getValueActualType(), getValueAnnotations());
+    }
+
+    private Annotation[] getValueAnnotations() {
+        return valueAnnotatedMapElementType.getDeclaredAnnotations();
+    }
+
     public Class<?> getKeyActualType() {
         return Parameterized.getClassFromType(keyAnnotatedMapElementType.getType(), "in Map key");
+    }
+
+    public JavaType getKeyActualJavaType() {
+        return new JavaType(getKeyActualType(), getKeyAnnotations());
+    }
+
+    private Annotation[] getKeyAnnotations() {
+        return keyAnnotatedMapElementType.getDeclaredAnnotations();
     }
 
     public ParameterizedMap getValueTypeAsMap() {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedMap.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/ParameterizedMap.java
@@ -15,19 +15,21 @@
  */
 package com.jerolba.carpet.impl;
 
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 
 public class ParameterizedMap {
 
     private final Type mapType;
-    private final Type keyType;
-    private final Type valueType;
+    private final AnnotatedType keyAnnotatedMapElementType;
+    private final AnnotatedType valueAnnotatedMapElementType;
 
-    public ParameterizedMap(Type mapType, ParameterizedType type) {
+    public ParameterizedMap(Type mapType, AnnotatedParameterizedType type) {
         this.mapType = mapType;
-        this.keyType = type.getActualTypeArguments()[0];
-        this.valueType = type.getActualTypeArguments()[1];
+        AnnotatedType[] annotatedActualTypeArguments = type.getAnnotatedActualTypeArguments();
+        this.keyAnnotatedMapElementType = annotatedActualTypeArguments[0];
+        this.valueAnnotatedMapElementType = annotatedActualTypeArguments[1];
     }
 
     public Class<?> getMapType() {
@@ -35,43 +37,35 @@ public class ParameterizedMap {
     }
 
     public Class<?> getValueActualType() {
-        return Parameterized.getClassFromType(valueType, "in Map value");
+        return Parameterized.getClassFromType(valueAnnotatedMapElementType.getType(), "in Map value");
     }
 
     public Class<?> getKeyActualType() {
-        return Parameterized.getClassFromType(keyType, "in Map key");
+        return Parameterized.getClassFromType(keyAnnotatedMapElementType.getType(), "in Map key");
     }
 
     public ParameterizedMap getValueTypeAsMap() {
-        if (valueType instanceof ParameterizedType paramType) {
-            Type map = paramType.getRawType();
-            return new ParameterizedMap(map, paramType);
-        }
-        return null;
+        return Parameterized.getParameterizedMap(valueAnnotatedMapElementType);
     }
 
     public ParameterizedCollection getValueTypeAsCollection() {
-        if (valueType instanceof ParameterizedType paramType) {
-            Type collection = paramType.getRawType();
-            return new ParameterizedCollection(collection, paramType);
-        }
-        return null;
+        return Parameterized.getParameterizedCollection(valueAnnotatedMapElementType);
     }
 
     public boolean valueIsCollection() {
-        return Parameterized.isCollection(valueType);
+        return Parameterized.isCollection(valueAnnotatedMapElementType.getType());
     }
 
     public boolean valueIsMap() {
-        return Parameterized.isMap(valueType);
+        return Parameterized.isMap(valueAnnotatedMapElementType.getType());
     }
 
     public boolean keyIsCollection() {
-        return Parameterized.isCollection(keyType);
+        return Parameterized.isCollection(keyAnnotatedMapElementType.getType());
     }
 
     public boolean keyIsMap() {
-        return Parameterized.isMap(keyType);
+        return Parameterized.isMap(keyAnnotatedMapElementType.getType());
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
@@ -121,7 +121,8 @@ public class CarpetGroupAsMapConverter extends GroupConverter {
         case DOUBLE -> new ToDoubleConverter(consumer);
         case BOOLEAN -> new BooleanConverter(consumer);
         case BINARY -> new BinaryConverter(consumer);
-        default -> throw new RecordTypeConversionException(type + " deserialization not supported");
+        case FIXED_LEN_BYTE_ARRAY, INT96 -> throw new RecordTypeConversionException(
+                type + " deserialization not supported");
         };
     }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/CarpetGroupAsMapConverter.java
@@ -45,6 +45,7 @@ import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
 
 import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.impl.read.converter.BinaryConverter;
 import com.jerolba.carpet.impl.read.converter.BooleanConverter;
 import com.jerolba.carpet.impl.read.converter.ToDoubleConverter;
 import com.jerolba.carpet.impl.read.converter.ToFloatConverter;
@@ -119,6 +120,7 @@ public class CarpetGroupAsMapConverter extends GroupConverter {
         case FLOAT -> new ToFloatConverter(consumer);
         case DOUBLE -> new ToDoubleConverter(consumer);
         case BOOLEAN -> new BooleanConverter(consumer);
+        case BINARY -> new BinaryConverter(consumer);
         default -> throw new RecordTypeConversionException(type + " deserialization not supported");
         };
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
@@ -86,6 +86,9 @@ class LogicalTypeConverters {
             if (type == null || type.isString()) {
                 return new StringConverter(consumer);
             }
+            if (type.isBinary()) {
+                return new BinaryConverter(consumer);
+            }
             if (type.isEnum()) {
                 return new EnumConverter(consumer, type.getJavaType());
             }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
@@ -78,8 +78,10 @@ class LogicalTypeConverters {
             }
         }
 
-        if (logicalTypeAnnotation.equals(bsonType()) && type.isBinary()) {
-            return new BinaryConverter(consumer);
+        if (logicalTypeAnnotation.equals(bsonType())) {
+            if (type == null || type.isBinary()) {
+                return new BinaryConverter(consumer);
+            }
         }
 
         if (logicalTypeAnnotation.equals(enumType())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
@@ -17,6 +17,7 @@ package com.jerolba.carpet.impl.read;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 
@@ -64,6 +65,15 @@ class LogicalTypeConverters {
             }
             if (type.isEnum()) {
                 return new EnumConverter(consumer, type.getJavaType());
+            }
+        }
+
+        if (logicalTypeAnnotation.equals(jsonType())) {
+            if (type == null || type.isString()) {
+                return new StringConverter(consumer);
+            }
+            if (type.isBinary()) {
+                return new BinaryConverter(consumer);
             }
         }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
@@ -31,6 +31,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 
 import com.jerolba.carpet.impl.JavaType;
+import com.jerolba.carpet.impl.read.converter.BinaryConverter;
 import com.jerolba.carpet.impl.read.converter.DecimalConverter;
 import com.jerolba.carpet.impl.read.converter.EnumConverter;
 import com.jerolba.carpet.impl.read.converter.InstantConverter;
@@ -57,6 +58,9 @@ class LogicalTypeConverters {
         if (logicalTypeAnnotation.equals(stringType())) {
             if (type == null || type.isString()) {
                 return new StringConverter(consumer);
+            }
+            if (type.isBinary()) {
+                return new BinaryConverter(consumer);
             }
             if (type.isEnum()) {
                 return new EnumConverter(consumer, type.getJavaType());

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/LogicalTypeConverters.java
@@ -15,6 +15,7 @@
  */
 package com.jerolba.carpet.impl.read;
 
+import static org.apache.parquet.schema.LogicalTypeAnnotation.bsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
@@ -75,6 +76,10 @@ class LogicalTypeConverters {
             if (type.isBinary()) {
                 return new BinaryConverter(consumer);
             }
+        }
+
+        if (logicalTypeAnnotation.equals(bsonType()) && type.isBinary()) {
+            return new BinaryConverter(consumer);
         }
 
         if (logicalTypeAnnotation.equals(enumType())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
@@ -25,6 +25,7 @@ import org.apache.parquet.schema.Type;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.impl.JavaType;
+import com.jerolba.carpet.impl.read.converter.BinaryConverter;
 import com.jerolba.carpet.impl.read.converter.BooleanConverter;
 import com.jerolba.carpet.impl.read.converter.ToByteConverter;
 import com.jerolba.carpet.impl.read.converter.ToDoubleConverter;
@@ -48,6 +49,7 @@ class PrimitiveConverterFactory {
         case INT32, INT64 -> buildFromIntConverter(consumer, javaType);
         case FLOAT, DOUBLE -> buildFromDecimalConverter(consumer, javaType);
         case BOOLEAN -> buildFromBooleanConverter(consumer, javaType);
+        case BINARY -> buildFromBinaryConverter(consumer, javaType);
         default -> throw new RecordTypeConversionException(type + " deserialization not supported");
         };
         if (converter == null) {
@@ -92,6 +94,13 @@ class PrimitiveConverterFactory {
     private static Converter buildFromBooleanConverter(Consumer<Object> consumer, JavaType type) {
         if (type.isBoolean()) {
             return new BooleanConverter(consumer);
+        }
+        return null;
+    }
+
+    private static Converter buildFromBinaryConverter(Consumer<Object> consumer, JavaType type) {
+        if (type.isBinary()) {
+            return new BinaryConverter(consumer);
         }
         return null;
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/PrimitiveConverterFactory.java
@@ -50,7 +50,8 @@ class PrimitiveConverterFactory {
         case FLOAT, DOUBLE -> buildFromDecimalConverter(consumer, javaType);
         case BOOLEAN -> buildFromBooleanConverter(consumer, javaType);
         case BINARY -> buildFromBinaryConverter(consumer, javaType);
-        default -> throw new RecordTypeConversionException(type + " deserialization not supported");
+        case FIXED_LEN_BYTE_ARRAY, INT96 -> throw new RecordTypeConversionException(
+                type + " deserialization not supported");
         };
         if (converter == null) {
             throw new RecordTypeConversionException(

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaFilter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaFilter.java
@@ -86,7 +86,8 @@ class SchemaFilter {
 
             if (parquetType.isPrimitive()) {
                 PrimitiveType primitiveType = parquetType.asPrimitiveType();
-                validation.validatePrimitiveCompatibility(primitiveType, recordComponent.getType());
+                JavaType javaType = new JavaType(recordComponent.getType(), recordComponent.getDeclaredAnnotations());
+                validation.validatePrimitiveCompatibility(primitiveType, javaType);
                 validation.validateNullability(primitiveType, recordComponent);
                 inProjection.put(parquetFieldName, parquetType);
                 continue;
@@ -168,7 +169,7 @@ class SchemaFilter {
             // if collection type is Java "primitive"
             var primitiveType = parquetType.asPrimitiveType();
             var actualCollectionType = parameterized.getActualType();
-            validation.validatePrimitiveCompatibility(primitiveType, actualCollectionType);
+            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(actualCollectionType));
             return parquetType;
         }
         // if collection type is Java "Record"
@@ -228,7 +229,7 @@ class SchemaFilter {
         if (childElement.isPrimitive()) {
             var primitiveType = childElement.asPrimitiveType();
             var actualCollectionType = parameterized.getActualType();
-            validation.validatePrimitiveCompatibility(primitiveType, actualCollectionType);
+            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(actualCollectionType));
             return parentGroupType;
         }
         var actualCollectionType = parameterized.getActualType();
@@ -267,7 +268,7 @@ class SchemaFilter {
         Class<?> keyActualType = parameterized.getKeyActualType();
         if (key.isPrimitive()) {
             PrimitiveType primitiveType = key.asPrimitiveType();
-            validation.validatePrimitiveCompatibility(primitiveType, keyActualType);
+            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(keyActualType));
         } else if (keyActualType.isRecord()) {
             key = filter(keyActualType, column, key.asGroupType());
         } else {
@@ -296,7 +297,7 @@ class SchemaFilter {
         } else {
             Class<?> valueActualType = parameterized.getValueActualType();
             if (value.isPrimitive()) {
-                validation.validatePrimitiveCompatibility(value.asPrimitiveType(), valueActualType);
+                validation.validatePrimitiveCompatibility(value.asPrimitiveType(), new JavaType(valueActualType));
             } else if (valueActualType.isRecord()) {
                 value = filter(valueActualType, column, value.asGroupType());
             } else {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaFilter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaFilter.java
@@ -168,8 +168,7 @@ class SchemaFilter {
         if (parquetType.isPrimitive()) {
             // if collection type is Java "primitive"
             var primitiveType = parquetType.asPrimitiveType();
-            var actualCollectionType = parameterized.getActualType();
-            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(actualCollectionType));
+            validation.validatePrimitiveCompatibility(primitiveType, parameterized.getActualJavaType());
             return parquetType;
         }
         // if collection type is Java "Record"
@@ -228,8 +227,7 @@ class SchemaFilter {
         }
         if (childElement.isPrimitive()) {
             var primitiveType = childElement.asPrimitiveType();
-            var actualCollectionType = parameterized.getActualType();
-            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(actualCollectionType));
+            validation.validatePrimitiveCompatibility(primitiveType, parameterized.getActualJavaType());
             return parentGroupType;
         }
         var actualCollectionType = parameterized.getActualType();
@@ -238,7 +236,7 @@ class SchemaFilter {
             Type listGroupMapped = rewrapListIfExists(listGroup, childMapped);
             return parentGroupType.withNewFields(listGroupMapped);
         }
-        if (isBasicSupportedType(new JavaType(actualCollectionType)) && !childElement.isPrimitive()) {
+        if (isBasicSupportedType(parameterized.getActualJavaType()) && !childElement.isPrimitive()) {
             throw new RecordTypeConversionException(
                     childElement.getName() + " is not compatible with " + actualCollectionType.getName());
         }
@@ -268,7 +266,7 @@ class SchemaFilter {
         Class<?> keyActualType = parameterized.getKeyActualType();
         if (key.isPrimitive()) {
             PrimitiveType primitiveType = key.asPrimitiveType();
-            validation.validatePrimitiveCompatibility(primitiveType, new JavaType(keyActualType));
+            validation.validatePrimitiveCompatibility(primitiveType, parameterized.getKeyActualJavaType());
         } else if (keyActualType.isRecord()) {
             key = filter(keyActualType, column, key.asGroupType());
         } else {
@@ -297,7 +295,8 @@ class SchemaFilter {
         } else {
             Class<?> valueActualType = parameterized.getValueActualType();
             if (value.isPrimitive()) {
-                validation.validatePrimitiveCompatibility(value.asPrimitiveType(), new JavaType(valueActualType));
+                validation.validatePrimitiveCompatibility(value.asPrimitiveType(),
+                        parameterized.getValueActualJavaType());
             } else if (valueActualType.isRecord()) {
                 value = filter(valueActualType, column, value.asGroupType());
             } else {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -161,7 +161,7 @@ public class SchemaValidation {
         if (bsonType().equals(logicalType) && type.isBinary()) {
             return name == PrimitiveTypeName.BINARY;
         }
-        if (enumType().equals(logicalType) && (type.isString() || type.isEnum())) {
+        if (enumType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (logicalType.equals(uuidType()) && (type.isString() || type.isUuid())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -64,8 +64,7 @@ public class SchemaValidation {
         return true;
     }
 
-    public boolean validatePrimitiveCompatibility(PrimitiveType primitiveType, Class<?> javaType) {
-        JavaType type = new JavaType(javaType);
+    public boolean validatePrimitiveCompatibility(PrimitiveType primitiveType, JavaType type) {
         LogicalTypeAnnotation logicalTypeAnnotation = primitiveType.getLogicalTypeAnnotation();
         if (logicalTypeAnnotation != null && validLogicalTypeAnnotation(primitiveType, type)) {
             return true;
@@ -151,7 +150,7 @@ public class SchemaValidation {
         var logicalType = primitiveType.getLogicalTypeAnnotation();
         var name = primitiveType.getPrimitiveTypeName();
 
-        if (stringType().equals(logicalType) && (type.isString() || type.isEnum())) {
+        if (stringType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (enumType().equals(logicalType) && (type.isString() || type.isEnum())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -78,7 +78,8 @@ public class SchemaValidation {
         case FLOAT -> validFloatSource(type);
         case DOUBLE -> validDoubleSource(type);
         case BOOLEAN -> validBooleanSource(type);
-        case BINARY, FIXED_LEN_BYTE_ARRAY, INT96 -> throwInvalidConversionException(primitiveType, type);
+        case BINARY -> validBinarySource(type);
+        case FIXED_LEN_BYTE_ARRAY, INT96 -> throwInvalidConversionException(primitiveType, type);
         default -> false;
         };
         if (!valid) {
@@ -141,6 +142,10 @@ public class SchemaValidation {
 
     private boolean validBooleanSource(JavaType type) {
         return type.isBoolean();
+    }
+
+    private boolean validBinarySource(JavaType type) {
+        return type.isBinary();
     }
 
     public static boolean isBasicSupportedType(JavaType type) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -160,13 +160,13 @@ public class SchemaValidation {
         if (stringType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
+        if (enumType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
+            return name == PrimitiveTypeName.BINARY;
+        }
         if (jsonType().equals(logicalType) && (type.isString() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (bsonType().equals(logicalType) && type.isBinary()) {
-            return name == PrimitiveTypeName.BINARY;
-        }
-        if (enumType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (logicalType.equals(uuidType()) && (type.isString() || type.isUuid())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -19,6 +19,7 @@ import static com.jerolba.carpet.impl.NotNullField.isNotNull;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 
@@ -151,6 +152,9 @@ public class SchemaValidation {
         var name = primitiveType.getPrimitiveTypeName();
 
         if (stringType().equals(logicalType) && (type.isString() || type.isEnum() || type.isBinary())) {
+            return name == PrimitiveTypeName.BINARY;
+        }
+        if (jsonType().equals(logicalType) && (type.isString() || type.isBinary())) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (enumType().equals(logicalType) && (type.isString() || type.isEnum())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/SchemaValidation.java
@@ -16,6 +16,7 @@
 package com.jerolba.carpet.impl.read;
 
 import static com.jerolba.carpet.impl.NotNullField.isNotNull;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.bsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
@@ -155,6 +156,9 @@ public class SchemaValidation {
             return name == PrimitiveTypeName.BINARY;
         }
         if (jsonType().equals(logicalType) && (type.isString() || type.isBinary())) {
+            return name == PrimitiveTypeName.BINARY;
+        }
+        if (bsonType().equals(logicalType) && type.isBinary()) {
             return name == PrimitiveTypeName.BINARY;
         }
         if (enumType().equals(logicalType) && (type.isString() || type.isEnum())) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/BinaryConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/BinaryConverter.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.read.converter;
+
+import java.util.function.Consumer;
+
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.PrimitiveConverter;
+
+public class BinaryConverter extends PrimitiveConverter {
+
+    private Binary[] dict = null;
+    private final Consumer<Object> consumer;
+
+    public BinaryConverter(Consumer<Object> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public void addBinary(Binary value) {
+        consumer.accept(convert(value));
+    }
+
+    @Override
+    public boolean hasDictionarySupport() {
+        return true;
+    }
+
+    @Override
+    public void setDictionary(Dictionary dictionary) {
+        int maxId = dictionary.getMaxId();
+        dict = new Binary[maxId + 1];
+        for (int i = 0; i <= maxId; i++) {
+            dict[i] = convert(dictionary.decodeToBinary(i));
+        }
+    }
+
+    @Override
+    public void addValueFromDictionary(int dictionaryId) {
+        consumer.accept(dict[dictionaryId]);
+    }
+
+    private Binary convert(Binary value) {
+        return value.copy();
+    }
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -35,6 +35,7 @@ import com.jerolba.carpet.model.MapType;
 import com.jerolba.carpet.model.SetType;
 import com.jerolba.carpet.model.ShortType;
 import com.jerolba.carpet.model.StringType;
+import com.jerolba.carpet.model.StringType.StringLogicalType;
 import com.jerolba.carpet.model.UuidType;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
@@ -130,4 +131,11 @@ class FieldTypeInspect {
         }
     }
 
+    public StringLogicalType stringLogicalType() {
+        if (fieldType instanceof StringType string) {
+            return string.logicalType();
+        } else {
+            throw new IllegalStateException("Field type is not a string type");
+        }
+    }
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -16,6 +16,8 @@
 package com.jerolba.carpet.impl.write;
 
 import com.jerolba.carpet.model.BigDecimalType;
+import com.jerolba.carpet.model.BinaryType;
+import com.jerolba.carpet.model.BinaryType.BinaryLogicalType;
 import com.jerolba.carpet.model.BooleanType;
 import com.jerolba.carpet.model.ByteType;
 import com.jerolba.carpet.model.DoubleType;
@@ -76,6 +78,10 @@ class FieldTypeInspect {
         return fieldType instanceof StringType;
     }
 
+    public boolean isBinary() {
+        return fieldType instanceof BinaryType;
+    }
+	
     public boolean isEnum() {
         return fieldType instanceof EnumType;
     }
@@ -114,6 +120,14 @@ class FieldTypeInspect {
 
     public boolean isMap() {
         return fieldType instanceof MapType;
+    }
+
+    public BinaryLogicalType binaryLogicalType() {
+        if (fieldType instanceof BinaryType binary) {
+            return binary.logicalType();
+        } else {
+            throw new IllegalStateException("Field type is not a binary type");
+        }
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -22,6 +22,7 @@ import com.jerolba.carpet.model.BooleanType;
 import com.jerolba.carpet.model.ByteType;
 import com.jerolba.carpet.model.DoubleType;
 import com.jerolba.carpet.model.EnumType;
+import com.jerolba.carpet.model.EnumType.EnumLogicalType;
 import com.jerolba.carpet.model.FieldType;
 import com.jerolba.carpet.model.FloatType;
 import com.jerolba.carpet.model.InstantType;
@@ -82,7 +83,7 @@ class FieldTypeInspect {
     public boolean isBinary() {
         return fieldType instanceof BinaryType;
     }
-	
+
     public boolean isEnum() {
         return fieldType instanceof EnumType;
     }
@@ -138,4 +139,13 @@ class FieldTypeInspect {
             throw new IllegalStateException("Field type is not a string type");
         }
     }
+
+    public EnumLogicalType enumLogicalType() {
+        if (fieldType instanceof EnumType enumType) {
+            return enumType.logicalType();
+        } else {
+            throw new IllegalStateException("Field type is not a enum type");
+        }
+    }
+
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -16,13 +16,12 @@
 package com.jerolba.carpet.impl.write;
 
 import com.jerolba.carpet.model.BigDecimalType;
+import com.jerolba.carpet.model.BinaryLogicalType;
 import com.jerolba.carpet.model.BinaryType;
-import com.jerolba.carpet.model.BinaryType.BinaryLogicalType;
 import com.jerolba.carpet.model.BooleanType;
 import com.jerolba.carpet.model.ByteType;
 import com.jerolba.carpet.model.DoubleType;
 import com.jerolba.carpet.model.EnumType;
-import com.jerolba.carpet.model.EnumType.EnumLogicalType;
 import com.jerolba.carpet.model.FieldType;
 import com.jerolba.carpet.model.FloatType;
 import com.jerolba.carpet.model.InstantType;
@@ -36,7 +35,6 @@ import com.jerolba.carpet.model.MapType;
 import com.jerolba.carpet.model.SetType;
 import com.jerolba.carpet.model.ShortType;
 import com.jerolba.carpet.model.StringType;
-import com.jerolba.carpet.model.StringType.StringLogicalType;
 import com.jerolba.carpet.model.UuidType;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
@@ -127,24 +125,12 @@ class FieldTypeInspect {
     public BinaryLogicalType binaryLogicalType() {
         if (fieldType instanceof BinaryType binary) {
             return binary.logicalType();
-        } else {
-            throw new IllegalStateException("Field type is not a binary type");
-        }
-    }
-
-    public StringLogicalType stringLogicalType() {
-        if (fieldType instanceof StringType string) {
+        } else if (fieldType instanceof StringType string) {
             return string.logicalType();
-        } else {
-            throw new IllegalStateException("Field type is not a string type");
-        }
-    }
-
-    public EnumLogicalType enumLogicalType() {
-        if (fieldType instanceof EnumType enumType) {
+        } else if (fieldType instanceof EnumType enumType) {
             return enumType.logicalType();
         } else {
-            throw new IllegalStateException("Field type is not a enum type");
+            throw new IllegalStateException("Field type is not a binary type");
         }
     }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldsWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldsWriter.java
@@ -58,6 +58,9 @@ class FieldsWriter {
         if (type.isShort() || type.isByte()) {
             return (consumer, v) -> consumer.addInteger(((Number) v).intValue());
         }
+        if (type.isBinary()) {
+            return (consumer, v) -> consumer.addBinary((Binary) v);
+        }
         if (type.isEnum()) {
             EnumsValues enumValues = new EnumsValues(type.getJavaType());
             return (consumer, v) -> consumer.addBinary(enumValues.getValue(v));

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -18,6 +18,7 @@ package com.jerolba.carpet.impl.write;
 import static com.jerolba.carpet.impl.NotNullField.isNotNull;
 import static com.jerolba.carpet.impl.Parameterized.getParameterizedCollection;
 import static com.jerolba.carpet.impl.Parameterized.getParameterizedMap;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.bsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
@@ -53,6 +54,7 @@ import org.apache.parquet.schema.Types;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.impl.JavaType;
@@ -216,6 +218,8 @@ class JavaRecord2Schema {
                 return primitive(BINARY, repetition).as(stringType()).named(name);
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 return primitive(BINARY, repetition).as(jsonType()).named(name);
+            } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
+                return primitive(BINARY, repetition).as(bsonType()).named(name);
             }
             throw new RecordTypeConversionException(
                     name + " Binary must be annotated with the type of Parquet LogicalType to use");

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -51,6 +51,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Types.PrimitiveBuilder;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
@@ -217,17 +218,17 @@ class JavaRecord2Schema {
             return primitive(BINARY, repetition).as(stringType()).named(name);
         }
         if (javaType.isBinary()) {
+            PrimitiveBuilder<PrimitiveType> binary = primitive(BINARY, repetition);
             if (javaType.isAnnotatedWith(ParquetString.class)) {
-                return primitive(BINARY, repetition).as(stringType()).named(name);
+                binary = binary.as(stringType());
             } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                return primitive(BINARY, repetition).as(enumType()).named(name);
+                binary = binary.as(enumType());
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                return primitive(BINARY, repetition).as(jsonType()).named(name);
+                binary = binary.as(jsonType());
             } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
-                return primitive(BINARY, repetition).as(bsonType()).named(name);
+                binary = binary.as(bsonType());
             }
-            throw new RecordTypeConversionException(
-                    name + " Binary must be annotated with the type of Parquet LogicalType to use");
+            return binary.named(name);
         }
 
         if (javaType.isEnum()) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -55,6 +55,7 @@ import org.apache.parquet.schema.Types;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.impl.JavaType;
@@ -210,12 +211,16 @@ class JavaRecord2Schema {
         if (javaType.isString()) {
             if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 return primitive(BINARY, repetition).as(jsonType()).named(name);
+            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+                return primitive(BINARY, repetition).as(enumType()).named(name);
             }
             return primitive(BINARY, repetition).as(stringType()).named(name);
         }
         if (javaType.isBinary()) {
             if (javaType.isAnnotatedWith(ParquetString.class)) {
                 return primitive(BINARY, repetition).as(stringType()).named(name);
+            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+                return primitive(BINARY, repetition).as(enumType()).named(name);
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 return primitive(BINARY, repetition).as(jsonType()).named(name);
             } else if (javaType.isAnnotatedWith(ParquetBson.class)) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -226,6 +226,9 @@ class JavaRecord2Schema {
         }
 
         if (javaType.isEnum()) {
+            if (javaType.isAnnotatedWith(ParquetString.class)) {
+                return primitive(BINARY, repetition).as(stringType()).named(name);
+            }
             return primitive(BINARY, repetition).as(enumType()).named(name);
         }
         if (javaType.isUuid()) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -18,18 +18,18 @@ package com.jerolba.carpet.impl.write;
 import static com.jerolba.carpet.impl.NotNullField.isNotNull;
 import static com.jerolba.carpet.impl.Parameterized.getParameterizedCollection;
 import static com.jerolba.carpet.impl.Parameterized.getParameterizedMap;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildDecimalTypeItem;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildInstantType;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildLocalDateTimeType;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildLocalDateType;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildLocalTimeType;
+import static com.jerolba.carpet.impl.write.SchemaBuilder.buildUuidType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.bsonType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
@@ -43,8 +43,6 @@ import java.util.Set;
 
 import org.apache.parquet.schema.ConversionPatterns;
 import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -54,7 +52,6 @@ import org.apache.parquet.schema.Types;
 import org.apache.parquet.schema.Types.PrimitiveBuilder;
 
 import com.jerolba.carpet.RecordTypeConversionException;
-import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetJson;
@@ -201,130 +198,74 @@ class JavaRecord2Schema {
     }
 
     private Type buildType(JavaType javaType, Set<Class<?>> visited, Repetition repetition, String name) {
-        PrimitiveType primitiveType = simpleTypeItems(javaType, repetition, name);
-        if (primitiveType != null) {
-            return primitiveType;
-        }
-        if (javaType.isRecord()) {
+        if (javaType.isInteger()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).named(name);
+        } else if (javaType.isLong()) {
+            return primitive(PrimitiveTypeName.INT64, repetition).named(name);
+        } else if (javaType.isFloat()) {
+            return primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
+        } else if (javaType.isDouble()) {
+            return primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
+        } else if (javaType.isBoolean()) {
+            return primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
+        } else if (javaType.isShort()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(16, true)).named(name);
+        } else if (javaType.isByte()) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(8, true)).named(name);
+        } else if (javaType.isString()) {
+            return buildStringType(javaType, repetition, name);
+        } else if (javaType.isBinary()) {
+            return buildBinaryType(javaType, repetition, name);
+        } else if (javaType.isEnum()) {
+            return buildEnumType(javaType, repetition, name);
+        } else if (javaType.isUuid()) {
+            return buildUuidType(repetition, name);
+        } else if (javaType.isBigDecimal()) {
+            return buildDecimalTypeItem(repetition, name, carpetConfiguration.decimalConfig());
+        } else if (javaType.isLocalDate()) {
+            return buildLocalDateType(repetition, name);
+        } else if (javaType.isLocalTime()) {
+            return buildLocalTimeType(repetition, name,
+                    carpetConfiguration.defaultTimeUnit(), carpetConfiguration.defaultTimeIsAdjustedToUTC());
+        } else if (javaType.isLocalDateTime()) {
+            return buildLocalDateTimeType(repetition, name, carpetConfiguration.defaultTimeUnit());
+        } else if (javaType.isInstant()) {
+            return buildInstantType(repetition, name, carpetConfiguration.defaultTimeUnit());
+        } else if (javaType.isRecord()) {
             List<Type> childFields = buildCompositeChild(javaType.getJavaType(), visited);
             return new GroupType(repetition, name, childFields);
         }
-        if (javaType.isString()) {
-            if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                return primitive(BINARY, repetition).as(jsonType()).named(name);
-            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                return primitive(BINARY, repetition).as(enumType()).named(name);
-            }
-            return primitive(BINARY, repetition).as(stringType()).named(name);
-        }
-        if (javaType.isBinary()) {
-            PrimitiveBuilder<PrimitiveType> binary = primitive(BINARY, repetition);
-            if (javaType.isAnnotatedWith(ParquetString.class)) {
-                binary = binary.as(stringType());
-            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                binary = binary.as(enumType());
-            } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                binary = binary.as(jsonType());
-            } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
-                binary = binary.as(bsonType());
-            }
-            return binary.named(name);
-        }
+        return null;
+    }
 
-        if (javaType.isEnum()) {
-            if (javaType.isAnnotatedWith(ParquetString.class)) {
-                return primitive(BINARY, repetition).as(stringType()).named(name);
-            }
+    private Type buildStringType(JavaType javaType, Repetition repetition, String name) {
+        if (javaType.isAnnotatedWith(ParquetJson.class)) {
+            return primitive(BINARY, repetition).as(jsonType()).named(name);
+        } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
             return primitive(BINARY, repetition).as(enumType()).named(name);
         }
-        if (javaType.isUuid()) {
-            return primitive(FIXED_LEN_BYTE_ARRAY, repetition).as(uuidType())
-                    .length(UUIDLogicalTypeAnnotation.BYTES)
-                    .named(name);
-        }
-        if (javaType.isBigDecimal()) {
-            return decimalTypeItem(repetition, name);
-        }
-        PrimitiveType dateTypeItems = dateTypeItems(javaType, repetition, name);
-        if (dateTypeItems != null) {
-            return dateTypeItems;
-        }
-        return null;
+        return primitive(BINARY, repetition).as(stringType()).named(name);
     }
 
-    private PrimitiveType simpleTypeItems(JavaType javaType, Repetition repetition, String name) {
-        if (javaType.isInteger()) {
-            return primitive(PrimitiveTypeName.INT32, repetition).named(name);
+    private Type buildBinaryType(JavaType javaType, Repetition repetition, String name) {
+        PrimitiveBuilder<PrimitiveType> binary = primitive(BINARY, repetition);
+        if (javaType.isAnnotatedWith(ParquetString.class)) {
+            binary = binary.as(stringType());
+        } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+            binary = binary.as(enumType());
+        } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
+            binary = binary.as(jsonType());
+        } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
+            binary = binary.as(bsonType());
         }
-        if (javaType.isLong()) {
-            return primitive(PrimitiveTypeName.INT64, repetition).named(name);
-        }
-        if (javaType.isFloat()) {
-            return primitive(PrimitiveTypeName.FLOAT, repetition).named(name);
-        }
-        if (javaType.isDouble()) {
-            return primitive(PrimitiveTypeName.DOUBLE, repetition).named(name);
-        }
-        if (javaType.isBoolean()) {
-            return primitive(PrimitiveTypeName.BOOLEAN, repetition).named(name);
-        }
-        if (javaType.isShort()) {
-            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(16, true)).named(name);
-        }
-        if (javaType.isByte()) {
-            return primitive(PrimitiveTypeName.INT32, repetition).as(intType(8, true)).named(name);
-        }
-        return null;
+        return binary.named(name);
     }
 
-    private PrimitiveType dateTypeItems(JavaType javaType, Repetition repetition, String name) {
-        if (javaType.isLocalDate()) {
-            return primitive(PrimitiveTypeName.INT32, repetition).as(dateType()).named(name);
+    private Type buildEnumType(JavaType javaType, Repetition repetition, String name) {
+        if (javaType.isAnnotatedWith(ParquetString.class)) {
+            return primitive(BINARY, repetition).as(stringType()).named(name);
         }
-        if (javaType.isLocalTime()) {
-            var timeUnit = carpetConfiguration.defaultTimeUnit();
-            var timeType = timeType(carpetConfiguration.defaultTimeIsAdjustedToUTC(), toParquetTimeUnit(timeUnit));
-            var typeName = switch (timeUnit) {
-            case MILLIS -> PrimitiveTypeName.INT32;
-            case MICROS, NANOS -> PrimitiveTypeName.INT64;
-            };
-            return primitive(typeName, repetition).as(timeType).named(name);
-        }
-        if (javaType.isLocalDateTime()) {
-            var timeUnit = carpetConfiguration.defaultTimeUnit();
-            var timeStampType = timestampType(false, toParquetTimeUnit(timeUnit));
-            return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
-        }
-        if (javaType.isInstant()) {
-            var timeUnit = carpetConfiguration.defaultTimeUnit();
-            var timeStampType = timestampType(true, toParquetTimeUnit(timeUnit));
-            return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
-        }
-        return null;
-    }
-
-    private static LogicalTypeAnnotation.TimeUnit toParquetTimeUnit(TimeUnit timeUnit) {
-        return switch (timeUnit) {
-        case MILLIS -> LogicalTypeAnnotation.TimeUnit.MILLIS;
-        case MICROS -> LogicalTypeAnnotation.TimeUnit.MICROS;
-        case NANOS -> LogicalTypeAnnotation.TimeUnit.NANOS;
-        };
-    }
-
-    private Type decimalTypeItem(Repetition repetition, String name) {
-        DecimalConfig decimalConfig = carpetConfiguration.decimalConfig();
-        if (!decimalConfig.arePrecisionAndScaleConfigured()) {
-            throw new RecordTypeConversionException("If BigDecimall is used, a Default Decimal configuration "
-                    + "must be provided in the setup of CarpetWriter builder");
-        }
-        var decimalType = decimalType(decimalConfig.scale(), decimalConfig.precision());
-        if (decimalConfig.precision() <= 9) {
-            return primitive(PrimitiveTypeName.INT32, repetition).as(decimalType).named(name);
-        }
-        if (decimalConfig.precision() <= 18) {
-            return primitive(PrimitiveTypeName.INT64, repetition).as(decimalType).named(name);
-        }
-        return primitive(PrimitiveTypeName.BINARY, repetition).as(decimalType).named(name);
+        return primitive(BINARY, repetition).as(enumType()).named(name);
     }
 
     private void validateNotVisitedRecord(Class<?> recordClass, Set<Class<?>> visited) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -137,7 +137,7 @@ class JavaRecord2Schema {
         if (parametized.isMap()) {
             return createMapType(fieldName, parametized.getParametizedAsMap(), visited, REPEATED);
         }
-        return buildTypeElement(new JavaType(parametized.getActualType()), visited, REPEATED, fieldName);
+        return buildTypeElement(parametized.getActualJavaType(), visited, REPEATED, fieldName);
     }
 
     private Type createCollectionTwoLevel(String fieldName, ParameterizedCollection parametized, Set<Class<?>> visited,
@@ -162,13 +162,12 @@ class JavaRecord2Schema {
         if (parametized.isMap()) {
             return createMapType("element", parametized.getParametizedAsMap(), visited, repetition);
         }
-        return buildTypeElement(new JavaType(parametized.getActualType()), visited, repetition, "element");
+        return buildTypeElement(parametized.getActualJavaType(), visited, repetition, "element");
     }
 
     private Type createMapType(String fieldName, ParameterizedMap parametized, Set<Class<?>> visited,
             Repetition repetition) {
-        Class<?> keyType = parametized.getKeyActualType();
-        Type nestedKey = buildTypeElement(new JavaType(keyType), visited, REQUIRED, "key");
+        Type nestedKey = buildTypeElement(parametized.getKeyActualJavaType(), visited, REQUIRED, "key");
 
         if (parametized.valueIsCollection()) {
             Type childCollection = createCollectionType("value", parametized.getValueTypeAsCollection(),
@@ -180,19 +179,18 @@ class JavaRecord2Schema {
             return Types.map(repetition).key(nestedKey).value(childMap).named(fieldName);
         }
 
-        Class<?> valueType = parametized.getValueActualType();
-        Type nestedValue = buildTypeElement(new JavaType(valueType), visited, OPTIONAL, "value");
+        Type nestedValue = buildTypeElement(parametized.getValueActualJavaType(), visited, OPTIONAL, "value");
         if (nestedKey != null && nestedValue != null) {
             // TODO: what to change to support generation of older versions?
             return Types.map(repetition).key(nestedKey).value(nestedValue).named(fieldName);
         }
-        throw new RecordTypeConversionException("Unsuported type in Map");
+        throw new RecordTypeConversionException("Unsupported type in Map");
     }
 
     private Type buildTypeElement(JavaType javaType, Set<Class<?>> visited, Repetition repetition, String name) {
         Type parquetType = buildType(javaType, visited, repetition, name);
         if (parquetType == null) {
-            throw new RecordTypeConversionException("Unsuported type " + javaType.getJavaType());
+            throw new RecordTypeConversionException("Unsupported type " + javaType.getJavaType());
         }
         return parquetType;
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2Schema.java
@@ -22,6 +22,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
@@ -52,6 +53,7 @@ import org.apache.parquet.schema.Types;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.impl.JavaType;
 import com.jerolba.carpet.impl.ParameterizedCollection;
@@ -204,11 +206,16 @@ class JavaRecord2Schema {
             return new GroupType(repetition, name, childFields);
         }
         if (javaType.isString()) {
+            if (javaType.isAnnotatedWith(ParquetJson.class)) {
+                return primitive(BINARY, repetition).as(jsonType()).named(name);
+            }
             return primitive(BINARY, repetition).as(stringType()).named(name);
         }
         if (javaType.isBinary()) {
             if (javaType.isAnnotatedWith(ParquetString.class)) {
                 return primitive(BINARY, repetition).as(stringType()).named(name);
+            } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
+                return primitive(BINARY, repetition).as(jsonType()).named(name);
             }
             throw new RecordTypeConversionException(
                     name + " Binary must be annotated with the type of Parquet LogicalType to use");

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.impl.JavaType;
@@ -179,6 +180,9 @@ public class JavaRecord2WriteModel {
                 return isNotNull ? binary.notNull() : binary;
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 BinaryType binary = FieldTypes.BINARY.asJson();
+                return isNotNull ? binary.notNull() : binary;
+            } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
+                BinaryType binary = FieldTypes.BINARY.asBson();
                 return isNotNull ? binary.notNull() : binary;
             }
             throw new RecordTypeConversionException(

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -101,15 +101,14 @@ public class JavaRecord2WriteModel {
         } else if (parametized.isMap()) {
             return LIST.ofType(createMapType(parametized.getParametizedAsMap(), visited));
         }
-        return LIST.ofType(simpleOrCompositeClass(new JavaType(parametized.getActualType()), false, visited));
+        return LIST.ofType(simpleOrCompositeClass(parametized.getActualJavaType(), false, visited));
     }
 
     private FieldType createMapType(ParameterizedMap parametized, Set<Class<?>> visited) {
-        Class<?> keyType = parametized.getKeyActualType();
         if (parametized.keyIsCollection() || parametized.keyIsMap()) {
             throw new RuntimeException("Maps with collections or maps as keys are not supported");
         }
-        FieldType nestedKey = simpleOrCompositeClass(new JavaType(keyType), false, visited);
+        FieldType nestedKey = simpleOrCompositeClass(parametized.getKeyActualJavaType(), false, visited);
 
         if (parametized.valueIsCollection()) {
             FieldType childCollection = createCollectionType(parametized.getValueTypeAsCollection(), visited);
@@ -118,7 +117,7 @@ public class JavaRecord2WriteModel {
             FieldType childMap = createMapType(parametized.getValueTypeAsMap(), visited);
             return MAP.ofTypes(nestedKey, childMap);
         }
-        FieldType nestedValue = simpleOrCompositeClass(new JavaType(parametized.getValueActualType()), false, visited);
+        FieldType nestedValue = simpleOrCompositeClass(parametized.getValueActualJavaType(), false, visited);
         if (nestedKey != null && nestedValue != null) {
             return MAP.ofTypes(nestedKey, nestedValue);
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -138,11 +138,6 @@ public class JavaRecord2WriteModel {
     }
 
     public static FieldType buildSimpleType(JavaType javaType, boolean isNotNull) {
-        FieldType javaPrimitiveType = javaPrimitiveTypes(javaType, isNotNull);
-        return javaPrimitiveType != null ? javaPrimitiveType : javaTypes(javaType, isNotNull);
-    }
-
-    private static FieldType javaPrimitiveTypes(JavaType javaType, boolean isNotNull) {
         if (javaType.isInteger()) {
             return isNotNull ? FieldTypes.INTEGER.notNull() : FieldTypes.INTEGER;
         }
@@ -164,39 +159,14 @@ public class JavaRecord2WriteModel {
         if (javaType.isByte()) {
             return isNotNull ? FieldTypes.BYTE.notNull() : FieldTypes.BYTE;
         }
-        return null;
-    }
-
-    private static FieldType javaTypes(JavaType javaType, boolean isNotNull) {
         if (javaType.isString()) {
-            StringType type = isNotNull ? FieldTypes.STRING.notNull() : FieldTypes.STRING;
-            if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                type = type.asJson();
-            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                type = type.asEnum();
-            }
-            return type;
+            return stringType(javaType, isNotNull);
         }
         if (javaType.isBinary()) {
-            BinaryType binary = FieldTypes.BINARY;
-            if (javaType.isAnnotatedWith(ParquetString.class)) {
-                binary = binary.asString();
-            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                binary = binary.asEnum();
-            } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                binary = binary.asJson();
-            } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
-                binary = binary.asBson();
-            }
-            return isNotNull ? binary.notNull() : binary;
+            return binaryType(javaType, isNotNull);
         }
         if (javaType.isEnum()) {
-            if (javaType.isAnnotatedWith(ParquetString.class)) {
-                BinaryType binary = FieldTypes.BINARY.asString();
-                return isNotNull ? binary.notNull() : binary;
-            }
-            EnumType enumType = FieldTypes.ENUM.ofType((Class<? extends Enum<?>>) javaType.getJavaType());
-            return isNotNull ? enumType.notNull() : enumType;
+            return enumType(javaType, isNotNull);
         }
         if (javaType.isUuid()) {
             return isNotNull ? FieldTypes.UUID.notNull() : FieldTypes.UUID;
@@ -217,6 +187,39 @@ public class JavaRecord2WriteModel {
             return isNotNull ? FieldTypes.INSTANT.notNull() : FieldTypes.INSTANT;
         }
         return null;
+    }
+
+    private static FieldType stringType(JavaType javaType, boolean isNotNull) {
+        StringType type = isNotNull ? FieldTypes.STRING.notNull() : FieldTypes.STRING;
+        if (javaType.isAnnotatedWith(ParquetJson.class)) {
+            type = type.asJson();
+        } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+            type = type.asEnum();
+        }
+        return type;
+    }
+
+    private static FieldType binaryType(JavaType javaType, boolean isNotNull) {
+        BinaryType binary = isNotNull ? FieldTypes.BINARY.notNull() : FieldTypes.BINARY;
+        if (javaType.isAnnotatedWith(ParquetString.class)) {
+            binary = binary.asString();
+        } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
+            binary = binary.asJson();
+        } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+            binary = binary.asEnum();
+        } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
+            binary = binary.asBson();
+        }
+        return binary;
+    }
+
+    private static FieldType enumType(JavaType javaType, boolean isNotNull) {
+        if (javaType.isAnnotatedWith(ParquetString.class)) {
+            BinaryType binary = FieldTypes.BINARY.asString();
+            return isNotNull ? binary.notNull() : binary;
+        }
+        EnumType enumType = FieldTypes.ENUM.ofType((Class<? extends Enum<?>>) javaType.getJavaType());
+        return isNotNull ? enumType.notNull() : enumType;
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.impl.JavaType;
@@ -171,12 +172,17 @@ public class JavaRecord2WriteModel {
             StringType type = isNotNull ? FieldTypes.STRING.notNull() : FieldTypes.STRING;
             if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 type = type.asJson();
+            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+                type = type.asEnum();
             }
             return type;
         }
         if (javaType.isBinary()) {
             if (javaType.isAnnotatedWith(ParquetString.class)) {
                 BinaryType binary = FieldTypes.BINARY.asString();
+                return isNotNull ? binary.notNull() : binary;
+            } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
+                BinaryType binary = FieldTypes.BINARY.asEnum();
                 return isNotNull ? binary.notNull() : binary;
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
                 BinaryType binary = FieldTypes.BINARY.asJson();
@@ -194,7 +200,7 @@ public class JavaRecord2WriteModel {
                 BinaryType binary = FieldTypes.BINARY.asString();
                 return isNotNull ? binary.notNull() : binary;
             }
-            EnumType enumType = new EnumType(false, (Class<? extends Enum<?>>) javaType.getJavaType());
+            EnumType enumType = FieldTypes.ENUM.ofType((Class<? extends Enum<?>>) javaType.getJavaType());
             return isNotNull ? enumType.notNull() : enumType;
         }
         if (javaType.isUuid()) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -190,6 +190,10 @@ public class JavaRecord2WriteModel {
 
         }
         if (javaType.isEnum()) {
+            if (javaType.isAnnotatedWith(ParquetString.class)) {
+                BinaryType binary = FieldTypes.BINARY.asString();
+                return isNotNull ? binary.notNull() : binary;
+            }
             EnumType enumType = new EnumType(false, (Class<? extends Enum<?>>) javaType.getJavaType());
             return isNotNull ? enumType.notNull() : enumType;
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/JavaRecord2WriteModel.java
@@ -178,22 +178,17 @@ public class JavaRecord2WriteModel {
             return type;
         }
         if (javaType.isBinary()) {
+            BinaryType binary = FieldTypes.BINARY;
             if (javaType.isAnnotatedWith(ParquetString.class)) {
-                BinaryType binary = FieldTypes.BINARY.asString();
-                return isNotNull ? binary.notNull() : binary;
+                binary = binary.asString();
             } else if (javaType.isAnnotatedWith(ParquetEnum.class)) {
-                BinaryType binary = FieldTypes.BINARY.asEnum();
-                return isNotNull ? binary.notNull() : binary;
+                binary = binary.asEnum();
             } else if (javaType.isAnnotatedWith(ParquetJson.class)) {
-                BinaryType binary = FieldTypes.BINARY.asJson();
-                return isNotNull ? binary.notNull() : binary;
+                binary = binary.asJson();
             } else if (javaType.isAnnotatedWith(ParquetBson.class)) {
-                BinaryType binary = FieldTypes.BINARY.asBson();
-                return isNotNull ? binary.notNull() : binary;
+                binary = binary.asBson();
             }
-            throw new RecordTypeConversionException(
-                    "Binary must be annotated with the type of Parquet LogicalType to use");
-
+            return isNotNull ? binary.notNull() : binary;
         }
         if (javaType.isEnum()) {
             if (javaType.isAnnotatedWith(ParquetString.class)) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
@@ -66,6 +66,9 @@ class ModelFieldsWriter {
         if (type.isShort() || type.isByte()) {
             return (consumer, v) -> consumer.addInteger(((Number) v).intValue());
         }
+        if (type.isBinary()) {
+            return (consumer, v) -> consumer.addBinary((Binary) v);
+        }		
         if (fieldType instanceof EnumType enumType) {
             EnumsValues enumValues = new EnumsValues(enumType.enumClass());
             return (consumer, v) -> consumer.addBinary(enumValues.getValue(v));

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/SchemaBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/SchemaBuilder.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.impl.write;
+
+import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.Types.primitive;
+
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Type.Repetition;
+
+import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.TimeUnit;
+
+class SchemaBuilder {
+
+    static PrimitiveType buildLocalTimeType(Repetition repetition, String name, TimeUnit timeUnit,
+            boolean isAdjustedToUTC) {
+        LogicalTypeAnnotation timeType = timeType(isAdjustedToUTC, toParquetTimeUnit(timeUnit));
+        var typeName = switch (timeUnit) {
+        case MILLIS -> PrimitiveTypeName.INT32;
+        case MICROS, NANOS -> PrimitiveTypeName.INT64;
+        };
+        return primitive(typeName, repetition).as(timeType).named(name);
+    }
+
+    static PrimitiveType buildLocalDateType(Repetition repetition, String name) {
+        return primitive(PrimitiveTypeName.INT32, repetition).as(dateType()).named(name);
+    }
+
+    static PrimitiveType buildLocalDateTimeType(Repetition repetition, String name, TimeUnit timeUnit) {
+        var timeStampType = timestampType(false, toParquetTimeUnit(timeUnit));
+        return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
+    }
+
+    static PrimitiveType buildInstantType(Repetition repetition, String name, TimeUnit timeUnit) {
+        var timeStampType = timestampType(true, toParquetTimeUnit(timeUnit));
+        return primitive(PrimitiveTypeName.INT64, repetition).as(timeStampType).named(name);
+    }
+
+    static Type buildDecimalTypeItem(Repetition repetition, String name, DecimalConfig decimalConfig) {
+        if (decimalConfig == null) {
+            throw new RecordTypeConversionException("If BigDecimall is used, a Default Decimal configuration "
+                    + "must be provided in the setup of CarpetWriter builder");
+        }
+        var decimalType = decimalType(decimalConfig.scale(), decimalConfig.precision());
+        if (decimalConfig.precision() <= 9) {
+            return primitive(PrimitiveTypeName.INT32, repetition).as(decimalType).named(name);
+        }
+        if (decimalConfig.precision() <= 18) {
+            return primitive(PrimitiveTypeName.INT64, repetition).as(decimalType).named(name);
+        }
+        return primitive(PrimitiveTypeName.BINARY, repetition).as(decimalType).named(name);
+    }
+
+    static Type buildUuidType(Repetition repetition, String name) {
+        return primitive(FIXED_LEN_BYTE_ARRAY, repetition).as(uuidType())
+                .length(UUIDLogicalTypeAnnotation.BYTES).named(name);
+    }
+
+    static LogicalTypeAnnotation.TimeUnit toParquetTimeUnit(TimeUnit timeUnit) {
+        return switch (timeUnit) {
+        case MILLIS -> LogicalTypeAnnotation.TimeUnit.MILLIS;
+        case MICROS -> LogicalTypeAnnotation.TimeUnit.MICROS;
+        case NANOS -> LogicalTypeAnnotation.TimeUnit.NANOS;
+        };
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -230,7 +230,7 @@ class WriteRecordModel2Schema {
         case JSON -> binary.as(jsonType()).named(parquetFieldName);
         case ENUM -> binary.as(enumType()).named(parquetFieldName);
         case STRING -> binary.as(stringType()).named(parquetFieldName);
-        default -> throw new RecordTypeConversionException("Unsupported logical type for String: " + logicalType);
+        case BSON -> throw new RecordTypeConversionException("Unsupported logical type for String: " + logicalType);
         };
     }
 
@@ -255,7 +255,8 @@ class WriteRecordModel2Schema {
         return switch (logicalType) {
         case STRING -> binary.as(stringType()).named(parquetFieldName);
         case ENUM -> binary.as(enumType()).named(parquetFieldName);
-        default -> throw new RecordTypeConversionException("Unsupported logical type for String: " + logicalType);
+        case BSON, JSON -> throw new RecordTypeConversionException(
+                "Unsupported logical type for String: " + logicalType);
         };
     }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -189,6 +189,12 @@ class WriteRecordModel2Schema {
         if (javaType.isString()) {
             return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
         }
+        if (javaType.isBinary()) {
+            return switch (javaType.binaryLogicalType()) {
+            case STRING -> primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
+            default -> null;
+            };
+        }
         if (javaType.isEnum()) {
             return primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -19,6 +19,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.jsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
@@ -51,6 +52,7 @@ import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.model.CollectionType;
 import com.jerolba.carpet.model.FieldType;
 import com.jerolba.carpet.model.MapType;
+import com.jerolba.carpet.model.StringType.StringLogicalType;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class WriteRecordModel2Schema {
@@ -187,11 +189,15 @@ class WriteRecordModel2Schema {
             return primitiveType;
         }
         if (javaType.isString()) {
+            if (javaType.stringLogicalType() == StringLogicalType.JSON) {
+                return primitive(BINARY, repetition).as(jsonType()).named(parquetFieldName);
+            }
             return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
         }
         if (javaType.isBinary()) {
             return switch (javaType.binaryLogicalType()) {
             case STRING -> primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
+            case JSON -> primitive(BINARY, repetition).as(jsonType()).named(parquetFieldName);
             default -> null;
             };
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -199,6 +199,9 @@ class WriteRecordModel2Schema {
             return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
         }
         if (javaType.isBinary()) {
+            if (javaType.binaryLogicalType() == null) {
+                return primitive(BINARY, repetition).named(parquetFieldName);
+            }
             return switch (javaType.binaryLogicalType()) {
             case STRING -> primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
             case ENUM -> primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -51,6 +51,7 @@ import org.apache.parquet.schema.Types;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.model.CollectionType;
+import com.jerolba.carpet.model.EnumType.EnumLogicalType;
 import com.jerolba.carpet.model.FieldType;
 import com.jerolba.carpet.model.MapType;
 import com.jerolba.carpet.model.StringType.StringLogicalType;
@@ -192,18 +193,24 @@ class WriteRecordModel2Schema {
         if (javaType.isString()) {
             if (javaType.stringLogicalType() == StringLogicalType.JSON) {
                 return primitive(BINARY, repetition).as(jsonType()).named(parquetFieldName);
+            } else if (javaType.stringLogicalType() == StringLogicalType.ENUM) {
+                return primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);
             }
             return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
         }
         if (javaType.isBinary()) {
             return switch (javaType.binaryLogicalType()) {
             case STRING -> primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
+            case ENUM -> primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);
             case JSON -> primitive(BINARY, repetition).as(jsonType()).named(parquetFieldName);
             case BSON -> primitive(BINARY, repetition).as(bsonType()).named(parquetFieldName);
             default -> null;
             };
         }
         if (javaType.isEnum()) {
+            if (javaType.enumLogicalType() == EnumLogicalType.STRING) {
+                return primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
+            }
             return primitive(BINARY, repetition).as(enumType()).named(parquetFieldName);
         }
         if (javaType.isUuid()) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteRecordModel2Schema.java
@@ -15,6 +15,7 @@
  */
 package com.jerolba.carpet.impl.write;
 
+import static org.apache.parquet.schema.LogicalTypeAnnotation.bsonType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
@@ -198,6 +199,7 @@ class WriteRecordModel2Schema {
             return switch (javaType.binaryLogicalType()) {
             case STRING -> primitive(BINARY, repetition).as(stringType()).named(parquetFieldName);
             case JSON -> primitive(BINARY, repetition).as(jsonType()).named(parquetFieldName);
+            case BSON -> primitive(BINARY, repetition).as(bsonType()).named(parquetFieldName);
             default -> null;
             };
         }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryLogicalType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryLogicalType.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+public enum BinaryLogicalType {
+    BSON, JSON, ENUM, STRING;
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -31,6 +31,10 @@ public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) imple
         return new BinaryType(isNotNull, BinaryLogicalType.STRING);
     }
 
+    public BinaryType asEnum() {
+        return new BinaryType(isNotNull, BinaryLogicalType.ENUM);
+    }
+
     public BinaryType asJson() {
         return new BinaryType(isNotNull, BinaryLogicalType.JSON);
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -35,6 +35,10 @@ public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) imple
         return new BinaryType(isNotNull, BinaryLogicalType.JSON);
     }
 
+    public BinaryType asBson() {
+        return new BinaryType(isNotNull, BinaryLogicalType.BSON);
+    }
+
     @Override
     public Class<Binary> getClassType() {
         return Binary.class;

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -19,10 +19,6 @@ import org.apache.parquet.io.api.Binary;
 
 public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) implements FieldType {
 
-    public enum BinaryLogicalType {
-        BSON, JSON, ENUM, STRING;
-    }
-
     public BinaryType notNull() {
         return new BinaryType(true, logicalType);
     }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -27,12 +27,12 @@ public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) imple
         return new BinaryType(true, logicalType);
     }
 
-    public BinaryType withLogicalType(BinaryLogicalType logicalType) {
-        return new BinaryType(isNotNull, logicalType);
-    }
-
     public BinaryType asString() {
         return new BinaryType(isNotNull, BinaryLogicalType.STRING);
+    }
+
+    public BinaryType asJson() {
+        return new BinaryType(isNotNull, BinaryLogicalType.JSON);
     }
 
     @Override

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -15,15 +15,29 @@
  */
 package com.jerolba.carpet.model;
 
-public sealed interface FieldType
-        permits BooleanType, ByteType, ShortType, IntegerType,
-        LongType, FloatType, DoubleType, StringType, BinaryType, EnumType,
-        UuidType, BigDecimalType, LocalDateType, LocalTimeType,
-        LocalDateTimeType, InstantType, CollectionType, ListType,
-        SetType, MapType, WriteRecordModelType {
+import org.apache.parquet.io.api.Binary;
 
-    boolean isNotNull();
+public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) implements FieldType {
 
-    Class<?> getClassType();
+    public enum BinaryLogicalType {
+        BSON, JSON, ENUM, STRING;
+    }
+
+    public BinaryType notNull() {
+        return new BinaryType(true, logicalType);
+    }
+
+    public BinaryType withLogicalType(BinaryLogicalType logicalType) {
+        return new BinaryType(isNotNull, logicalType);
+    }
+
+    public BinaryType asString() {
+        return new BinaryType(isNotNull, BinaryLogicalType.STRING);
+    }
+
+    @Override
+    public Class<Binary> getClassType() {
+        return Binary.class;
+    }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
@@ -15,10 +15,19 @@
  */
 package com.jerolba.carpet.model;
 
-public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass) implements FieldType {
+public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass, EnumLogicalType logicalType)
+        implements FieldType {
+
+    public enum EnumLogicalType {
+        JSON, ENUM, STRING;
+    }
 
     public EnumType notNull() {
-        return new EnumType(true, enumClass);
+        return new EnumType(true, enumClass, logicalType);
+    }
+
+    public EnumType asString() {
+        return new EnumType(isNotNull, enumClass, EnumLogicalType.STRING);
     }
 
     @Override

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
@@ -15,11 +15,19 @@
  */
 package com.jerolba.carpet.model;
 
-public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass, EnumLogicalType logicalType)
+import java.util.Set;
+
+public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass, BinaryLogicalType logicalType)
         implements FieldType {
 
-    public enum EnumLogicalType {
-        ENUM, STRING;
+    private static final Set<BinaryLogicalType> VALID_LOGICAL_TYPES = Set.of(
+            BinaryLogicalType.STRING,
+            BinaryLogicalType.ENUM);
+
+    public EnumType {
+        if (logicalType != null && !VALID_LOGICAL_TYPES.contains(logicalType)) {
+            throw new IllegalArgumentException("Invalid logical type for StringType: " + logicalType);
+        }
     }
 
     public EnumType notNull() {
@@ -27,7 +35,7 @@ public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass, En
     }
 
     public EnumType asString() {
-        return new EnumType(isNotNull, enumClass, EnumLogicalType.STRING);
+        return new EnumType(isNotNull, enumClass, BinaryLogicalType.STRING);
     }
 
     @Override

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumType.java
@@ -19,7 +19,7 @@ public record EnumType(boolean isNotNull, Class<? extends Enum<?>> enumClass, En
         implements FieldType {
 
     public enum EnumLogicalType {
-        JSON, ENUM, STRING;
+        ENUM, STRING;
     }
 
     public EnumType notNull() {

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
@@ -15,18 +15,16 @@
  */
 package com.jerolba.carpet.model;
 
-import com.jerolba.carpet.model.EnumType.EnumLogicalType;
-
 public class EnumTypeBuilder {
 
     private final boolean notNull;
-    private final EnumLogicalType logicalType;
+    private final BinaryLogicalType logicalType;
 
     EnumTypeBuilder() {
         this(false, null);
     }
 
-    private EnumTypeBuilder(boolean notNull, EnumLogicalType logicalType) {
+    private EnumTypeBuilder(boolean notNull, BinaryLogicalType logicalType) {
         this.notNull = notNull;
         this.logicalType = logicalType;
     }
@@ -36,7 +34,7 @@ public class EnumTypeBuilder {
     }
 
     public EnumTypeBuilder asString() {
-        return new EnumTypeBuilder(notNull, EnumLogicalType.STRING);
+        return new EnumTypeBuilder(notNull, BinaryLogicalType.STRING);
     }
 
     public EnumType ofType(Class<? extends Enum<?>> enumClass) {

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/EnumTypeBuilder.java
@@ -15,24 +15,32 @@
  */
 package com.jerolba.carpet.model;
 
+import com.jerolba.carpet.model.EnumType.EnumLogicalType;
+
 public class EnumTypeBuilder {
 
     private final boolean notNull;
+    private final EnumLogicalType logicalType;
 
     EnumTypeBuilder() {
-        this(false);
+        this(false, null);
     }
 
-    private EnumTypeBuilder(boolean notNull) {
+    private EnumTypeBuilder(boolean notNull, EnumLogicalType logicalType) {
         this.notNull = notNull;
+        this.logicalType = logicalType;
     }
 
     public EnumTypeBuilder notNull() {
-        return new EnumTypeBuilder(true);
+        return new EnumTypeBuilder(true, logicalType);
+    }
+
+    public EnumTypeBuilder asString() {
+        return new EnumTypeBuilder(notNull, EnumLogicalType.STRING);
     }
 
     public EnumType ofType(Class<? extends Enum<?>> enumClass) {
-        return new EnumType(notNull, enumClass);
+        return new EnumType(notNull, enumClass, logicalType);
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
@@ -24,7 +24,7 @@ public class FieldTypes {
     public static final LongType LONG = new LongType(false);
     public static final FloatType FLOAT = new FloatType(false);
     public static final DoubleType DOUBLE = new DoubleType(false);
-    public static final StringType STRING = new StringType(false);
+    public static final StringType STRING = new StringType(false, null);
     public static final BinaryType BINARY = new BinaryType(false, null);
     public static final EnumTypeBuilder ENUM = new EnumTypeBuilder();
     public static final UuidType UUID = new UuidType(false);

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
@@ -25,6 +25,7 @@ public class FieldTypes {
     public static final FloatType FLOAT = new FloatType(false);
     public static final DoubleType DOUBLE = new DoubleType(false);
     public static final StringType STRING = new StringType(false);
+    public static final BinaryType BINARY = new BinaryType(false, null);
     public static final EnumTypeBuilder ENUM = new EnumTypeBuilder();
     public static final UuidType UUID = new UuidType(false);
     public static final BigDecimalType BIG_DECIMAL = new BigDecimalType(false);

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/StringType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/StringType.java
@@ -15,10 +15,19 @@
  */
 package com.jerolba.carpet.model;
 
-public record StringType(boolean isNotNull, StringLogicalType logicalType) implements FieldType {
+import java.util.Set;
 
-    public enum StringLogicalType {
-        JSON, ENUM, STRING;
+public record StringType(boolean isNotNull, BinaryLogicalType logicalType) implements FieldType {
+
+    private static final Set<BinaryLogicalType> VALID_LOGICAL_TYPES = Set.of(
+            BinaryLogicalType.STRING,
+            BinaryLogicalType.ENUM,
+            BinaryLogicalType.JSON);
+
+    public StringType {
+        if (logicalType != null && !VALID_LOGICAL_TYPES.contains(logicalType)) {
+            throw new IllegalArgumentException("Invalid logical type for StringType: " + logicalType);
+        }
     }
 
     public StringType notNull() {
@@ -26,11 +35,11 @@ public record StringType(boolean isNotNull, StringLogicalType logicalType) imple
     }
 
     public StringType asJson() {
-        return new StringType(isNotNull, StringLogicalType.JSON);
+        return new StringType(isNotNull, BinaryLogicalType.JSON);
     }
 
     public StringType asEnum() {
-        return new StringType(isNotNull, StringLogicalType.ENUM);
+        return new StringType(isNotNull, BinaryLogicalType.ENUM);
     }
 
     @Override

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetString;
 
 class JavaRecord2SchemaTest {
 
@@ -118,6 +120,22 @@ class JavaRecord2SchemaTest {
                 message NotNullFieldRecord {
                   required int64 id;
                   required binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schema.toString());
+    }
+
+    @Test
+    void BinaryAsStringRecordTest() {
+        record SimpleRecord(long id, @ParquetString Binary name) {
+        }
+
+        MessageType schema = defaultConfigSchema.createSchema(SimpleRecord.class);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary name (STRING);
                 }
                 """;
         assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -43,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 
@@ -198,6 +199,40 @@ class JavaRecord2SchemaTest {
                     message JsonRecord {
                       required int64 id;
                       required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class BsonType {
+
+        @Test
+        void bsonFieldFromBinary() {
+            record BsonRecord(long id, @ParquetBson Binary value) {
+            }
+            MessageType schema = defaultConfigSchema.createSchema(BsonRecord.class);
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      optional binary value (BSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullBsonFieldFromBinary() {
+            record BsonRecord(long id, @ParquetBson @NotNull Binary value) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(BsonRecord.class);
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      required binary value (BSON);
                     }
                     """;
             assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -129,7 +129,7 @@ class JavaRecord2SchemaTest {
     }
 
     @Test
-    void BinaryAsStringRecordTest() {
+    void binaryAsStringRecordTest() {
         record SimpleRecord(long id, @ParquetString Binary name) {
         }
 
@@ -139,6 +139,22 @@ class JavaRecord2SchemaTest {
                 message SimpleRecord {
                   required int64 id;
                   optional binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schema.toString());
+    }
+
+    @Test
+    void unannotatedBinaryHasNoLogicalType() {
+        record SimpleRecord(long id, Binary data) {
+        }
+
+        MessageType schema = defaultConfigSchema.createSchema(SimpleRecord.class);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary data;
                 }
                 """;
         assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -665,6 +665,22 @@ class JavaRecord2SchemaTest {
             assertEquals(expected, schema.toString());
         }
 
+        @Test
+        void enumAsString() {
+            record WithStringEnum(long id, String name, @ParquetString Status status) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(WithStringEnum.class);
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -44,6 +44,7 @@ import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
 import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 
@@ -676,6 +677,38 @@ class JavaRecord2SchemaTest {
                       required int64 id;
                       optional binary name (STRING);
                       optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void stringAsEnum() {
+            record WithStringEnum(long id, String name, @ParquetEnum String status) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(WithStringEnum.class);
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void binaryAsEnum() {
+            record WithBinaryEnum(long id, String name, @ParquetEnum Binary status) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(WithBinaryEnum.class);
+            String expected = """
+                    message WithBinaryEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
                     }
                     """;
             assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -43,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 
 class JavaRecord2SchemaTest {
@@ -139,6 +140,69 @@ class JavaRecord2SchemaTest {
                 }
                 """;
         assertEquals(expected, schema.toString());
+    }
+
+    @Nested
+    class JsonType {
+
+        @Test
+        void jsonFieldFromString() {
+            record JsonRecord(long id, @ParquetJson String value) {
+            }
+            MessageType schema = defaultConfigSchema.createSchema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromString() {
+            record JsonRecord(long id, @ParquetJson @NotNull String value) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void jsonFieldFromBinary() {
+            record JsonRecord(long id, @ParquetJson Binary value) {
+            }
+            MessageType schema = defaultConfigSchema.createSchema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromBinary() {
+            record JsonRecord(long id, @ParquetJson @NotNull Binary value) {
+            }
+
+            MessageType schema = defaultConfigSchema.createSchema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecord2SchemaTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Locale.Category;
 import java.util.Map;
 import java.util.UUID;
 
@@ -790,6 +791,96 @@ class JavaRecord2SchemaTest {
         }
 
         @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values;
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (BSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
         void consecutiveNestedCollections() {
             record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
             }
@@ -914,6 +1005,108 @@ class JavaRecord2SchemaTest {
                         repeated group element {
                           optional binary str (STRING);
                         }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (STRING);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (ENUM);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (ENUM);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (JSON);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element;
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (BSON);
                       }
                     }
                     """;
@@ -1210,6 +1403,120 @@ class JavaRecord2SchemaTest {
         }
 
         @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (STRING);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (ENUM);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (ENUM);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (JSON);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (BSON);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
         void nestedRecordCollection() {
 
             record ChildRecord(String id, Boolean loaded) {
@@ -1368,6 +1675,58 @@ class JavaRecord2SchemaTest {
                             optional group alias (LIST) {
                               repeated group list {
                                 optional binary element (STRING);
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveNestedAnnotatedTypeCollection() {
+
+            record ConsecutiveNestedAnnotatedTypeCollection(String id, List<List<@ParquetJson String>> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(ConsecutiveNestedAnnotatedTypeCollection.class);
+            String expected = """
+                    message ConsecutiveNestedAnnotatedTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional binary element (JSON);
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void consecutiveTripleNestedAnnotatedTypeCollections() {
+            record ConsecutiveTripleNestedAnnotatedTypeCollections(String id,
+                    List<List<List<@ParquetBson Binary>>> values) {
+            }
+
+            MessageType schema = schemaFactory.createSchema(ConsecutiveTripleNestedAnnotatedTypeCollections.class);
+            String expected = """
+                    message ConsecutiveTripleNestedAnnotatedTypeCollections {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional group element (LIST) {
+                            repeated group list {
+                              optional group element (LIST) {
+                                repeated group list {
+                                  optional binary element (BSON);
+                                }
                               }
                             }
                           }

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class JavaRecordMapper2SchemaTest {
@@ -118,6 +120,22 @@ class JavaRecordMapper2SchemaTest {
                 message NotNullFieldRecord {
                   required int64 id;
                   required binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schema.toString());
+    }
+
+    @Test
+    void BinaryAsStringRecordTest() {
+        record SimpleRecord(long id, @ParquetString Binary name) {
+        }
+
+        MessageType schema = class2Model2Schema(SimpleRecord.class);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary name (STRING);
                 }
                 """;
         assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -43,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
@@ -139,6 +140,69 @@ class JavaRecordMapper2SchemaTest {
                 }
                 """;
         assertEquals(expected, schema.toString());
+    }
+
+    @Nested
+    class JsonType {
+
+        @Test
+        void jsonFieldFromString() {
+            record JsonRecord(long id, @ParquetJson String value) {
+            }
+            MessageType schema = class2Model2Schema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromString() {
+            record JsonRecord(long id, @ParquetJson @NotNull String value) {
+            }
+
+            MessageType schema = class2Model2Schema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void jsonFieldFromBinary() {
+            record JsonRecord(long id, @ParquetJson Binary value) {
+            }
+            MessageType schema = class2Model2Schema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromBinary() {
+            record JsonRecord(long id, @ParquetJson @NotNull Binary value) {
+            }
+
+            MessageType schema = class2Model2Schema(JsonRecord.class);
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Locale.Category;
 import java.util.Map;
 import java.util.UUID;
 
@@ -775,6 +776,96 @@ class JavaRecordMapper2SchemaTest {
         }
 
         @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values;
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, oneLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      repeated binary values (BSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
         void consecutiveNestedCollections() {
             record ConsecutiveNestedCollection(String id, List<List<Integer>> values) {
             }
@@ -898,6 +989,108 @@ class JavaRecordMapper2SchemaTest {
                         repeated group element {
                           optional binary str (STRING);
                         }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (STRING);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (ENUM);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (ENUM);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (JSON);
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element;
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class, twoLevel);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated binary element (BSON);
                       }
                     }
                     """;
@@ -1184,6 +1377,120 @@ class JavaRecordMapper2SchemaTest {
                       optional group values (LIST) {
                         repeated group list {
                           optional int32 element (INTEGER(8,true));
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringCollection() {
+            record SimpleTypeCollection(String id, List<String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (STRING);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedStringAsEnumCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetEnum String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (ENUM);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedEnumCollection() {
+            record SimpleTypeCollection(String id, List<Category> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (ENUM);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedJsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetJson String> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (JSON);
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBinaryCollection() {
+            record SimpleTypeCollection(String id, List<Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element;
+                        }
+                      }
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void nestedBsonCollection() {
+            record SimpleTypeCollection(String id, List<@ParquetBson Binary> values) {
+            }
+
+            MessageType schema = class2Model2Schema(SimpleTypeCollection.class);
+            String expected = """
+                    message SimpleTypeCollection {
+                      optional binary id (STRING);
+                      optional group values (LIST) {
+                        repeated group list {
+                          optional binary element (BSON);
                         }
                       }
                     }

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -129,7 +129,7 @@ class JavaRecordMapper2SchemaTest {
     }
 
     @Test
-    void BinaryAsStringRecordTest() {
+    void binaryAsStringRecordTest() {
         record SimpleRecord(long id, @ParquetString Binary name) {
         }
 
@@ -139,6 +139,22 @@ class JavaRecordMapper2SchemaTest {
                 message SimpleRecord {
                   required int64 id;
                   optional binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schema.toString());
+    }
+
+    @Test
+    void unannotatedBinaryHasNoLogicalType() {
+        record SimpleRecord(long id, Binary data) {
+        }
+
+        MessageType schema = class2Model2Schema(SimpleRecord.class);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary data;
                 }
                 """;
         assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -44,6 +44,7 @@ import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
 import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
@@ -662,6 +663,38 @@ class JavaRecordMapper2SchemaTest {
                       required int64 id;
                       optional binary name (STRING);
                       optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void stringAsEnum() {
+            record WithStringEnum(long id, String name, @ParquetEnum String status) {
+            }
+
+            MessageType schema = class2Model2Schema(WithStringEnum.class);
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void binaryAsEnum() {
+            record WithBinaryEnum(long id, String name, @ParquetEnum Binary status) {
+            }
+
+            MessageType schema = class2Model2Schema(WithBinaryEnum.class);
+            String expected = """
+                    message WithBinaryEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
                     }
                     """;
             assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -651,6 +651,22 @@ class JavaRecordMapper2SchemaTest {
             assertEquals(expected, schema.toString());
         }
 
+        @Test
+        void enumAsString() {
+            record WithStringEnum(long id, String name, @ParquetString Status status) {
+            }
+
+            MessageType schema = class2Model2Schema(WithStringEnum.class);
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -43,6 +43,7 @@ import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
+import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
@@ -198,6 +199,40 @@ class JavaRecordMapper2SchemaTest {
                     message JsonRecord {
                       required int64 id;
                       required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class BsonType {
+
+        @Test
+        void bsonFieldFromBinary() {
+            record BsonRecord(long id, @ParquetBson Binary value) {
+            }
+            MessageType schema = class2Model2Schema(BsonRecord.class);
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      optional binary value (BSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullBsonFieldFromBinary() {
+            record BsonRecord(long id, @ParquetBson @NotNull Binary value) {
+            }
+
+            MessageType schema = class2Model2Schema(BsonRecord.class);
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      required binary value (BSON);
                     }
                     """;
             assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -59,7 +59,6 @@ import com.jerolba.carpet.AnnotatedLevels;
 import com.jerolba.carpet.ColumnNamingStrategy;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
-import com.jerolba.carpet.model.BinaryType.BinaryLogicalType;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class WriteRecord2SchemaTest {
@@ -165,7 +164,7 @@ class WriteRecord2SchemaTest {
 
         var rootType = writeRecordModel(SimpleRecord.class)
                 .withField("id", LONG.notNull(), SimpleRecord::id)
-                .withField("name", BINARY.withLogicalType(BinaryLogicalType.STRING), SimpleRecord::name);
+                .withField("name", BINARY.asString(), SimpleRecord::name);
 
         String expected = """
                 message SimpleRecord {
@@ -174,6 +173,83 @@ class WriteRecord2SchemaTest {
                 }
                 """;
         assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Nested
+    class JsonType {
+
+        @Test
+        void jsonFieldFromString() {
+            record JsonRecord(long id, String value) {
+            }
+
+            var rootType = writeRecordModel(JsonRecord.class)
+                    .withField("id", LONG.notNull(), JsonRecord::id)
+                    .withField("value", STRING.asJson(), JsonRecord::value);
+
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromString() {
+            record JsonRecord(long id, String value) {
+            }
+
+            var rootType = writeRecordModel(JsonRecord.class)
+                    .withField("id", LONG.notNull(), JsonRecord::id)
+                    .withField("value", STRING.asJson().notNull(), JsonRecord::value);
+
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void jsonFieldFromBinary() {
+            record JsonRecord(long id, Binary value) {
+            }
+
+            var rootType = writeRecordModel(JsonRecord.class)
+                    .withField("id", LONG.notNull(), JsonRecord::id)
+                    .withField("value", BINARY.asJson(), JsonRecord::value);
+
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      optional binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void notNullJsonFieldFromBinary() {
+            record JsonRecord(long id, Binary value) {
+            }
+
+            var rootType = writeRecordModel(JsonRecord.class)
+                    .withField("id", LONG.notNull(), JsonRecord::id)
+                    .withField("value", BINARY.asJson().notNull(), JsonRecord::value);
+
+            String expected = """
+                    message JsonRecord {
+                      required int64 id;
+                      required binary value (JSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -59,7 +59,6 @@ import com.jerolba.carpet.AnnotatedLevels;
 import com.jerolba.carpet.ColumnNamingStrategy;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
-import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class WriteRecord2SchemaTest {
@@ -783,19 +782,59 @@ class WriteRecord2SchemaTest {
 
         @Test
         void enumAsString() {
-            record WithStringEnum(long id, String name, @ParquetString Status status) {
+            record WithStringEnum(long id, String name, Status status) {
             }
 
             var rootType = writeRecordModel(WithStringEnum.class)
                     .withField("id", LONG.notNull(), WithStringEnum::id)
                     .withField("name", STRING, WithStringEnum::name)
-                    .withField("status", STRING, WithStringEnum::status);
+                    .withField("status", ENUM.ofType(Status.class).asString(), WithStringEnum::status);
 
             String expected = """
                     message WithStringEnum {
                       required int64 id;
                       optional binary name (STRING);
                       optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void stringAsEnum() {
+            record WithStringEnum(long id, String name, String status) {
+            }
+
+            var rootType = writeRecordModel(WithStringEnum.class)
+                    .withField("id", LONG.notNull(), WithStringEnum::id)
+                    .withField("name", STRING, WithStringEnum::name)
+                    .withField("status", STRING.asEnum(), WithStringEnum::status);
+
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void binaryAsEnum() {
+            record WithBinaryEnum(long id, String name, Binary status) {
+            }
+
+            var rootType = writeRecordModel(WithBinaryEnum.class)
+                    .withField("id", LONG.notNull(), WithBinaryEnum::id)
+                    .withField("name", STRING, WithBinaryEnum::name)
+                    .withField("status", BINARY.asEnum(), WithBinaryEnum::status);
+
+            String expected = """
+                    message WithBinaryEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (ENUM);
                     }
                     """;
             assertEquals(expected, schemaWithRootType(rootType).toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -59,6 +59,7 @@ import com.jerolba.carpet.AnnotatedLevels;
 import com.jerolba.carpet.ColumnNamingStrategy;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class WriteRecord2SchemaTest {
@@ -768,18 +769,37 @@ class WriteRecord2SchemaTest {
             var rootType = writeRecordModel(WithNotNullEnum.class)
                     .withField("id", LONG.notNull(), WithNotNullEnum::id)
                     .withField("name", STRING, WithNotNullEnum::name)
-                    .withField("state", ENUM.ofType(Status.class).notNull(), WithNotNullEnum::status);
+                    .withField("status", ENUM.ofType(Status.class).notNull(), WithNotNullEnum::status);
 
             String expected = """
                     message WithNotNullEnum {
                       required int64 id;
                       optional binary name (STRING);
-                      required binary state (ENUM);
+                      required binary status (ENUM);
                     }
                     """;
             assertEquals(expected, schemaWithRootType(rootType).toString());
         }
 
+        @Test
+        void enumAsString() {
+            record WithStringEnum(long id, String name, @ParquetString Status status) {
+            }
+
+            var rootType = writeRecordModel(WithStringEnum.class)
+                    .withField("id", LONG.notNull(), WithStringEnum::id)
+                    .withField("name", STRING, WithStringEnum::name)
+                    .withField("status", STRING, WithStringEnum::status);
+
+            String expected = """
+                    message WithStringEnum {
+                      required int64 id;
+                      optional binary name (STRING);
+                      optional binary status (STRING);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
     }
 
     @Nested

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -253,6 +253,47 @@ class WriteRecord2SchemaTest {
     }
 
     @Nested
+    class BsonType {
+
+        @Test
+        void bsonFieldFromBinary() {
+            record BsonRecord(long id, Binary value) {
+            }
+
+            var rootType = writeRecordModel(BsonRecord.class)
+                    .withField("id", LONG.notNull(), BsonRecord::id)
+                    .withField("value", BINARY.asBson(), BsonRecord::value);
+
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      optional binary value (BSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+        @Test
+        void notNullBsonFieldFromBinary() {
+            record BsonRecord(long id, Binary value) {
+            }
+
+            var rootType = writeRecordModel(BsonRecord.class)
+                    .withField("id", LONG.notNull(), BsonRecord::id)
+                    .withField("value", BINARY.asBson().notNull(), BsonRecord::value);
+
+            String expected = """
+                    message BsonRecord {
+                      required int64 id;
+                      required binary value (BSON);
+                    }
+                    """;
+            assertEquals(expected, schemaWithRootType(rootType).toString());
+        }
+
+    }
+
+    @Nested
     class DecimalConfiguration {
 
         @Test

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -175,6 +175,24 @@ class WriteRecord2SchemaTest {
         assertEquals(expected, schemaWithRootType(rootType).toString());
     }
 
+    @Test
+    void unannotatedBinaryHasNoLogicalType() {
+        record SimpleRecord(long id, Binary name) {
+        }
+
+        var rootType = writeRecordModel(SimpleRecord.class)
+                .withField("id", LONG.notNull(), SimpleRecord::id)
+                .withField("data", BINARY, SimpleRecord::name);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary data;
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
     @Nested
     class JsonType {
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/WriteRecord2SchemaTest.java
@@ -20,6 +20,7 @@ import static com.jerolba.carpet.TimeUnit.MILLIS;
 import static com.jerolba.carpet.TimeUnit.NANOS;
 import static com.jerolba.carpet.impl.write.DecimalConfig.decimalConfig;
 import static com.jerolba.carpet.model.FieldTypes.BIG_DECIMAL;
+import static com.jerolba.carpet.model.FieldTypes.BINARY;
 import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
 import static com.jerolba.carpet.model.FieldTypes.BYTE;
 import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
@@ -49,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,7 @@ import com.jerolba.carpet.AnnotatedLevels;
 import com.jerolba.carpet.ColumnNamingStrategy;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.model.BinaryType.BinaryLogicalType;
 import com.jerolba.carpet.model.WriteRecordModelType;
 
 class WriteRecord2SchemaTest {
@@ -150,6 +153,24 @@ class WriteRecord2SchemaTest {
                 message NotNullFieldRecord {
                   required int64 id;
                   required binary name (STRING);
+                }
+                """;
+        assertEquals(expected, schemaWithRootType(rootType).toString());
+    }
+
+    @Test
+    void binaryAsStringRecordTest() {
+        record SimpleRecord(long id, Binary name) {
+        }
+
+        var rootType = writeRecordModel(SimpleRecord.class)
+                .withField("id", LONG.notNull(), SimpleRecord::id)
+                .withField("name", BINARY.withLogicalType(BinaryLogicalType.STRING), SimpleRecord::name);
+
+        String expected = """
+                message SimpleRecord {
+                  required int64 id;
+                  optional binary name (STRING);
                 }
                 """;
         assertEquals(expected, schemaWithRootType(rootType).toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
@@ -74,6 +74,7 @@ import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.ReadFlag;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.annotation.Alias;
+import com.jerolba.carpet.annotation.ParquetEnum;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.io.FileSystemInputFile;
 import com.jerolba.carpet.io.FileSystemOutputFile;
@@ -477,6 +478,31 @@ class CarpetReaderTest {
             try (var carpetReader = readerTest.getCarpetReader(EnumObject.class)) {
                 assertEquals(new EnumObject(Category.one), carpetReader.read());
                 assertEquals(new EnumObject(Category.two), carpetReader.read());
+            }
+        }
+
+        @Test
+        void enumToBinaryObject() throws IOException {
+            Schema schema = schemaType("EnumObject").name("value").type().nullable()
+                    .enumeration("Category").symbols("one", "two", "three").noDefault()
+                    .endRecord();
+
+            var readerTest = new ParquetReaderTest(schema);
+            readerTest.writer(writer -> {
+                Record record = new Record(schema);
+                record.put("value", "one");
+                writer.write(record);
+                record = new Record(schema);
+                record.put("value", "two");
+                writer.write(record);
+            });
+
+            record BinaryFromEnumObject(@ParquetEnum Binary value) {
+            }
+
+            try (var carpetReader = readerTest.getCarpetReader(BinaryFromEnumObject.class)) {
+                assertEquals(new BinaryFromEnumObject(Binary.fromString("one")), carpetReader.read());
+                assertEquals(new BinaryFromEnumObject(Binary.fromString("two")), carpetReader.read());
             }
         }
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
@@ -18,6 +18,7 @@ package com.jerolba.carpet.reader;
 import static com.jerolba.carpet.FieldMatchingStrategy.BEST_EFFORT;
 import static com.jerolba.carpet.FieldMatchingStrategy.FIELD_NAME;
 import static com.jerolba.carpet.FieldMatchingStrategy.SNAKE_CASE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -453,6 +454,29 @@ class CarpetReaderTest {
             try (var carpetReader = readerTest.getCarpetReader(StringAsBinaryObject.class)) {
                 assertEquals(new StringAsBinaryObject(Binary.fromString("Madrid")), carpetReader.read());
                 assertEquals(new StringAsBinaryObject(Binary.fromString("Zaragoza")), carpetReader.read());
+            }
+        }
+
+        @Test
+        void binaryObject() throws IOException {
+            Schema schema = schemaType("BinaryObject").optionalBytes("value").endRecord();
+
+            var readerTest = new ParquetReaderTest(schema);
+            readerTest.writer(writer -> {
+                Record record = new Record(schema);
+                record.put("value", "Madrid".getBytes(UTF_8));
+                writer.write(record);
+                record = new Record(schema);
+                record.put("value", "Zaragoza".getBytes(UTF_8));
+                writer.write(record);
+            });
+
+            record BinaryObject(Binary value) {
+            }
+
+            try (var carpetReader = readerTest.getCarpetReader(BinaryObject.class)) {
+                assertEquals(new BinaryObject(Binary.fromString("Madrid")), carpetReader.read());
+                assertEquals(new BinaryObject(Binary.fromString("Zaragoza")), carpetReader.read());
             }
         }
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
@@ -506,6 +506,31 @@ class CarpetReaderTest {
         }
 
         @Test
+        void enumToStringObject() throws IOException {
+            Schema schema = schemaType("EnumObject").name("value").type().nullable()
+                    .enumeration("Category").symbols("one", "two", "three").noDefault()
+                    .endRecord();
+
+            var readerTest = new ParquetReaderTest(schema);
+            readerTest.writer(writer -> {
+                Record record = new Record(schema);
+                record.put("value", "one");
+                writer.write(record);
+                record = new Record(schema);
+                record.put("value", "two");
+                writer.write(record);
+            });
+
+            record StringFromEnumObject(String value) {
+            }
+
+            try (var carpetReader = readerTest.getCarpetReader(StringFromEnumObject.class)) {
+                assertEquals(new StringFromEnumObject("one"), carpetReader.read());
+                assertEquals(new StringFromEnumObject("two"), carpetReader.read());
+            }
+        }
+
+        @Test
         void enumToBinaryObject() throws IOException {
             Schema schema = schemaType("EnumObject").name("value").type().nullable()
                     .enumeration("Category").symbols("one", "two", "three").noDefault()

--- a/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/reader/CarpetReaderTest.java
@@ -59,6 +59,7 @@ import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -73,6 +74,7 @@ import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.ReadFlag;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.annotation.Alias;
+import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.io.FileSystemInputFile;
 import com.jerolba.carpet.io.FileSystemOutputFile;
 
@@ -427,6 +429,29 @@ class CarpetReaderTest {
             try (var carpetReader = readerTest.getCarpetReader(StringObject.class)) {
                 assertEquals(new StringObject("Madrid"), carpetReader.read());
                 assertEquals(new StringObject("Zaragoza"), carpetReader.read());
+            }
+        }
+
+        @Test
+        void stringAsBinaryObject() throws IOException {
+            Schema schema = schemaType("StringAsBinaryObject").optionalString("value").endRecord();
+
+            var readerTest = new ParquetReaderTest(schema);
+            readerTest.writer(writer -> {
+                Record record = new Record(schema);
+                record.put("value", "Madrid");
+                writer.write(record);
+                record = new Record(schema);
+                record.put("value", "Zaragoza");
+                writer.write(record);
+            });
+
+            record StringAsBinaryObject(@ParquetString Binary value) {
+            }
+
+            try (var carpetReader = readerTest.getCarpetReader(StringAsBinaryObject.class)) {
+                assertEquals(new StringAsBinaryObject(Binary.fromString("Madrid")), carpetReader.read());
+                assertEquals(new StringAsBinaryObject(Binary.fromString("Zaragoza")), carpetReader.read());
             }
         }
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterCollectionThreeLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterCollectionThreeLevelTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -29,12 +30,20 @@ import java.util.Set;
 import org.apache.avro.generic.GenericData.Array;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Test;
 
 import com.jerolba.carpet.ParquetWriterTest;
+import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetJson;
 
 //Verification with Avro is done considering that parser can not read List > element structures correctly
 class CarpetWriterCollectionThreeLevelTest {
+
+    enum Category {
+        FOO, BAR
+    }
 
     @Test
     void simpleTypeCollection() throws IOException {
@@ -58,6 +67,170 @@ class CarpetWriterCollectionThreeLevelTest {
         assertEquals(1.2, amount.get(0).get("element"));
         assertEquals(3.2, amount.get(1).get("element"));
 
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<String> values) {
+        }
+
+        var rec = new SimpleTypeCollection("foo", List.of("foo", "bar"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        assertEquals("foo", ids.get(0).get("element").toString());
+        assertEquals("bar", ids.get(1).get("element").toString());
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringAsEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetEnum String> values) {
+        }
+
+        var rec = new SimpleTypeCollection("foo", List.of("FOO", "BAR"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        assertEquals("FOO", ids.get(0).get("element").toString());
+        assertEquals("BAR", ids.get(1).get("element").toString());
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+
+        record AsEnum(String name, List<Category> values) {
+        }
+
+        var recEnum = new AsEnum("foo", List.of(Category.FOO, Category.BAR));
+        var carpetReaderEnum = writerTest.getCarpetReader(AsEnum.class);
+        assertEquals(recEnum, carpetReaderEnum.read());
+    }
+
+    @Test
+    void simpleEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Category> values) {
+        }
+
+        var rec = new SimpleTypeCollection("foo", List.of(Category.FOO, Category.BAR));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        assertEquals("FOO", ids.get(0).get("element").toString());
+        assertEquals("BAR", ids.get(1).get("element").toString());
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleJsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetJson String> values) {
+        }
+
+        var rec = new SimpleTypeCollection("foo",
+                List.of("{\"key\": 1, \"value\": \"foo\"}", "{\"key\": 2, \"value\": \"bar\"}"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        // Avro does not support JSON, so we need to convert it to a string
+        assertEquals(rec.values().get(0), new String(((ByteBuffer) ids.get(0).get("element")).array(), "UTF-8"));
+        assertEquals(rec.values().get(1), new String(((ByteBuffer) ids.get(1).get("element")).array(), "UTF-8"));
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBinaryCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Binary> values) {
+        }
+
+        byte[] binary1 = new byte[] { 1, 2 };
+        byte[] binary2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(binary1), Binary.fromConstantByteArray(binary2)));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        byte[] fromAvro1 = ((ByteBuffer) ids.get(0).get("element")).array();
+        assertEquals(binary1.length, fromAvro1.length);
+        for (int i = 0; i < binary1.length; i++) {
+            assertEquals(binary1[i], fromAvro1[i]);
+        }
+        byte[] fromAvro2 = ((ByteBuffer) ids.get(1).get("element")).array();
+        assertEquals(binary2.length, fromAvro2.length);
+        for (int i = 0; i < binary2.length; i++) {
+            assertEquals(binary2[i], fromAvro2[i]);
+        }
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetBson Binary> values) {
+        }
+
+        byte[] mockBson1 = new byte[] { 1, 2 };
+        byte[] mockBson2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(mockBson1), Binary.fromConstantByteArray(mockBson2)));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class);
+        writerTest.write(rec);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec.name(), avroRecord.get("name").toString());
+
+        Array<GenericRecord> ids = (Array<GenericRecord>) avroRecord.get("values");
+        assertEquals(2, ids.size());
+        // Avro does not support BSON
+        byte[] fromAvro1 = ((ByteBuffer) ids.get(0).get("element")).array();
+        assertEquals(mockBson1.length, fromAvro1.length);
+        for (int i = 0; i < mockBson1.length; i++) {
+            assertEquals(mockBson1[i], fromAvro1[i]);
+        }
+        byte[] fromAvro2 = ((ByteBuffer) ids.get(1).get("element")).array();
+        assertEquals(mockBson2.length, fromAvro2.length);
+        for (int i = 0; i < mockBson2.length; i++) {
+            assertEquals(mockBson2[i], fromAvro2[i]);
+        }
         var carpetReader = writerTest.getCarpetReader();
         assertEquals(rec, carpetReader.read());
     }

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
@@ -480,6 +480,33 @@ class CarpetWriterTest {
         }
 
         @Test
+        void enumAsStringObject() throws IOException {
+
+            record EnumObject(@ParquetString Category value) {
+            }
+
+            var rec1 = new EnumObject(Category.one);
+            var rec2 = new EnumObject(Category.two);
+            var writerTest = new ParquetWriterTest<>(EnumObject.class);
+            writerTest.write(rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.name(), avroReader.read().get("value").toString());
+            assertEquals(rec2.value.name(), avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+
+            record EnumStringObject(String value) {
+            }
+
+            var carpetReaderString = writerTest.getCarpetReader(EnumStringObject.class);
+            assertEquals(new EnumStringObject("one"), carpetReaderString.read());
+            assertEquals(new EnumStringObject("two"), carpetReaderString.read());
+        }
+
+        @Test
         void uuidObject() throws IOException {
 
             record UuidObject(UUID value) {

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
@@ -461,6 +461,25 @@ class CarpetWriterTest {
         }
 
         @Test
+        void justBinaryObject() throws IOException {
+
+            record JustBinaryObject(Binary value) {
+            }
+
+            byte[] byteArray = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            var rec = new JustBinaryObject(Binary.fromConstantByteArray(byteArray));
+            var writerTest = new ParquetWriterTest<>(JustBinaryObject.class);
+            writerTest.write(rec);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            ByteBuffer asByteBuffer = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec.value, Binary.fromReusedByteBuffer(asByteBuffer));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec, carpetReader.read());
+        }
+
+        @Test
         void enumObject() throws IOException {
 
             record EnumObject(Category value) {

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
@@ -41,6 +41,7 @@ import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,7 @@ import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
 import com.jerolba.carpet.annotation.Alias;
+import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.io.FileSystemInputFile;
 import com.jerolba.carpet.io.FileSystemOutputFile;
 
@@ -358,6 +360,26 @@ class CarpetWriterTest {
             var avroReader = writerTest.getAvroGenericRecordReader();
             assertEquals(rec1.value, avroReader.read().get("value").toString());
             assertEquals(rec2.value, avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void stringBinaryObject() throws IOException {
+
+            record StringObject(@ParquetString Binary value) {
+            }
+
+            var rec1 = new StringObject(Binary.fromString("Madrid"));
+            var rec2 = new StringObject(Binary.fromString("Zaragoza"));
+            var writerTest = new ParquetWriterTest<>(StringObject.class);
+            writerTest.write(rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.toStringUsingUTF8(), avroReader.read().get("value").toString());
+            assertEquals(rec2.value.toStringUsingUTF8(), avroReader.read().get("value").toString());
 
             var carpetReader = writerTest.getCarpetReader();
             assertEquals(rec1, carpetReader.read());

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionOneLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionOneLevelTest.java
@@ -16,8 +16,10 @@
 package com.jerolba.carpet.writer;
 
 import static com.jerolba.carpet.AnnotatedLevels.ONE;
+import static com.jerolba.carpet.model.FieldTypes.BINARY;
 import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
 import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.ENUM;
 import static com.jerolba.carpet.model.FieldTypes.INTEGER;
 import static com.jerolba.carpet.model.FieldTypes.LIST;
 import static com.jerolba.carpet.model.FieldTypes.MAP;
@@ -33,10 +35,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Test;
 
 import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.RecordTypeConversionException;
+import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetJson;
+import com.jerolba.carpet.writer.CarpetWriterCollectionThreeLevelTest.Category;
 
 class WriteRecordModelWriterCollectionOneLevelTest {
 
@@ -52,6 +59,128 @@ class WriteRecordModelWriterCollectionOneLevelTest {
                 .withField("amount", LIST.ofType(DOUBLE), SimpleTypeCollection::amount);
 
         var rec = new SimpleTypeCollection("foo", List.of(1, 2, 3), List.of(1.2, 3.2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of("foo", "bar"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringAsEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetEnum String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING.asEnum()), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of("FOO", "BAR"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+
+        record AsEnum(String name, List<Category> values) {
+        }
+
+        var recEnum = new AsEnum("foo", List.of(Category.FOO, Category.BAR));
+        var carpetReaderEnum = writerTest.getCarpetReader(AsEnum.class);
+        assertEquals(recEnum, carpetReaderEnum.read());
+    }
+
+    @Test
+    void simpleEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Category> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(ENUM.ofType(Category.class)), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of(Category.FOO, Category.BAR));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleJsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetJson String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING.asJson()), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo",
+                List.of("{\"key\": 1, \"value\": \"foo\"}", "{\"key\": 2, \"value\": \"bar\"}"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBinaryCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(BINARY), SimpleTypeCollection::values);
+
+        byte[] binary1 = new byte[] { 1, 2 };
+        byte[] binary2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(binary1), Binary.fromConstantByteArray(binary2)));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetBson Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(BINARY.asBson()), SimpleTypeCollection::values);
+
+        byte[] mockBson1 = new byte[] { 1, 2 };
+        byte[] mockBson2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(mockBson1), Binary.fromConstantByteArray(mockBson2)));
         var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(ONE);
         writerTest.write(mapper, rec);
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
@@ -16,8 +16,10 @@
 package com.jerolba.carpet.writer;
 
 import static com.jerolba.carpet.AnnotatedLevels.TWO;
+import static com.jerolba.carpet.model.FieldTypes.BINARY;
 import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
 import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
+import static com.jerolba.carpet.model.FieldTypes.ENUM;
 import static com.jerolba.carpet.model.FieldTypes.INTEGER;
 import static com.jerolba.carpet.model.FieldTypes.LIST;
 import static com.jerolba.carpet.model.FieldTypes.MAP;
@@ -34,9 +36,14 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Test;
 
 import com.jerolba.carpet.ParquetWriterTest;
+import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetJson;
+import com.jerolba.carpet.writer.CarpetWriterCollectionThreeLevelTest.Category;
 
 class WriteRecordModelWriterCollectionTwoLevelTest {
 
@@ -52,6 +59,128 @@ class WriteRecordModelWriterCollectionTwoLevelTest {
                 .withField("amount", LIST.ofType(DOUBLE), SimpleTypeCollection::amount);
 
         var rec = new SimpleTypeCollection("foo", List.of(1, 2, 3), List.of(1.2, 3.2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of("foo", "bar"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleStringAsEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetEnum String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING.asEnum()), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of("FOO", "BAR"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+
+        record AsEnum(String name, List<Category> values) {
+        }
+
+        var recEnum = new AsEnum("foo", List.of(Category.FOO, Category.BAR));
+        var carpetReaderEnum = writerTest.getCarpetReader(AsEnum.class);
+        assertEquals(recEnum, carpetReaderEnum.read());
+    }
+
+    @Test
+    void simpleEnumCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Category> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(ENUM.ofType(Category.class)), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo", List.of(Category.FOO, Category.BAR));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleJsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetJson String> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(STRING.asJson()), SimpleTypeCollection::values);
+
+        var rec = new SimpleTypeCollection("foo",
+                List.of("{\"key\": 1, \"value\": \"foo\"}", "{\"key\": 2, \"value\": \"bar\"}"));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBinaryCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(BINARY), SimpleTypeCollection::values);
+
+        byte[] binary1 = new byte[] { 1, 2 };
+        byte[] binary2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(binary1), Binary.fromConstantByteArray(binary2)));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec, carpetReader.read());
+    }
+
+    @Test
+    void simpleBsonCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetBson Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(BINARY.asBson()), SimpleTypeCollection::values);
+
+        byte[] mockBson1 = new byte[] { 1, 2 };
+        byte[] mockBson2 = new byte[] { 3, 4 };
+        var rec = new SimpleTypeCollection("foo",
+                List.of(Binary.fromConstantByteArray(mockBson1), Binary.fromConstantByteArray(mockBson2)));
         var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
         writerTest.write(mapper, rec);
 

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterMapTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterMapTest.java
@@ -27,16 +27,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Test;
 
 import com.jerolba.carpet.ParquetWriterTest;
+import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetJson;
 
 class WriteRecordModelWriterMapTest {
+
+    enum Category {
+        FOO, BAR
+    }
 
     @Test
     void mapPrimitiveValue() throws IOException {
@@ -53,6 +63,17 @@ class WriteRecordModelWriterMapTest {
         var rec2 = new MapPrimitiveValue("bar", mapOf("ABCD", 3, "EFGH", 4), mapOf("ABCD", 2.2, "EFGH", 3.3));
         var writerTest = new ParquetWriterTest<>(MapPrimitiveValue.class);
         writerTest.write(mapper, rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(rec1.ids(), unUtf8Map(avroRecord.get("ids")));
+        assertEquals(rec1.amount(), unUtf8Map(avroRecord.get("amount")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(rec2.ids(), unUtf8Map(avroRecord.get("ids")));
+        assertEquals(rec2.amount(), unUtf8Map(avroRecord.get("amount")));
 
         var carpetReader = writerTest.getCarpetReader();
         assertEquals(rec1, carpetReader.read());
@@ -74,6 +95,17 @@ class WriteRecordModelWriterMapTest {
         var rec2 = new MapPrimitiveValueNull("bar", mapOf("ABCD", null, "EFGH", 4), mapOf("ABCD", 2.2, "EFGH", null));
         var writerTest = new ParquetWriterTest<>(MapPrimitiveValueNull.class);
         writerTest.write(mapper, rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(rec1.ids(), unUtf8Map(avroRecord.get("ids")));
+        assertEquals(rec1.amount(), unUtf8Map(avroRecord.get("amount")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(rec2.ids(), unUtf8Map(avroRecord.get("ids")));
+        assertEquals(rec2.amount(), unUtf8Map(avroRecord.get("amount")));
 
         var carpetReader = writerTest.getCarpetReader();
         assertEquals(rec1, carpetReader.read());
@@ -104,6 +136,140 @@ class WriteRecordModelWriterMapTest {
                 "CAT", new ChildRecord("Barcelona", true)));
         var writerTest = new ParquetWriterTest<>(MapRecordValue.class);
         writerTest.write(mapper, rec1, rec2);
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapStringKeyAndValue() throws IOException {
+
+        record MapValues(String name, Map<String, String> values) {
+        }
+
+        var rec1 = new MapValues("foo", Map.of("ABCD", "ONE", "EFGH", "TWO"));
+        var rec2 = new MapValues("bar", Map.of("ABCD", "THREE", "EFGH", "FOUR"));
+        var writerTest = new ParquetWriterTest<>(MapValues.class);
+        writerTest.write(rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(rec1.values(), unUtf8Map(avroRecord.get("values")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(rec2.values(), unUtf8Map(avroRecord.get("values")));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapStringAsEnumValue() throws IOException {
+
+        record MapValues(String name, Map<String, @ParquetEnum String> values) {
+        }
+
+        var rec1 = new MapValues("foo", Map.of("FOO", "BAR", "BAR", "FOO"));
+        var rec2 = new MapValues("bar", Map.of("FOO", "FOO", "BAR", "BAR"));
+        var writerTest = new ParquetWriterTest<>(MapValues.class);
+        writerTest.write(rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(rec1.values(), unUtf8Map(avroRecord.get("values")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(rec2.values(), unUtf8Map(avroRecord.get("values")));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+
+        record MapValuesAsEnum(String name, Map<String, Category> values) {
+        }
+
+        var carpetReaderAsEnum = writerTest.getCarpetReader(MapValuesAsEnum.class);
+        assertEquals(new MapValuesAsEnum("foo", Map.of("FOO", Category.BAR, "BAR", Category.FOO)),
+                carpetReaderAsEnum.read());
+        assertEquals(new MapValuesAsEnum("bar", Map.of("FOO", Category.FOO, "BAR", Category.BAR)),
+                carpetReaderAsEnum.read());
+    }
+
+    @Test
+    void mapEnumValue() throws IOException {
+
+        record MapValues(String name, Map<String, Category> values) {
+        }
+
+        var rec1 = new MapValues("foo", Map.of("FOO", Category.BAR, "BAR", Category.FOO));
+        var rec2 = new MapValues("bar", Map.of("FOO", Category.FOO, "BAR", Category.BAR));
+        var writerTest = new ParquetWriterTest<>(MapValues.class);
+        writerTest.write(rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(Map.of("FOO", "BAR", "BAR", "FOO"), unUtf8Map(avroRecord.get("values")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(Map.of("FOO", "FOO", "BAR", "BAR"), unUtf8Map(avroRecord.get("values")));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapJsonValue() throws IOException {
+
+        record MapValues(String name, Map<String, @ParquetJson String> values) {
+        }
+
+        var rec1 = new MapValues("foo", Map.of("FOO", "{}", "BAR", "{\"key1\": \"value1\"}"));
+        var rec2 = new MapValues("bar", Map.of("FOO", "{\"key2\": \"value2\"}", "BAR", "{}"));
+        var writerTest = new ParquetWriterTest<>(MapValues.class);
+        writerTest.write(rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(rec1.values(), unByteBufferMap(avroRecord.get("values")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(rec2.values(), unByteBufferMap(avroRecord.get("values")));
+
+        var carpetReader = writerTest.getCarpetReader();
+        assertEquals(rec1, carpetReader.read());
+        assertEquals(rec2, carpetReader.read());
+    }
+
+    @Test
+    void mapBinaryValue() throws IOException {
+
+        record MapValues(String name, Map<String, Binary> values) {
+        }
+
+        var rec1 = new MapValues("foo", Map.of("FOO", Binary.fromString("BAR"), "BAR", Binary.fromString("FOO")));
+        var rec2 = new MapValues("bar", Map.of("FOO", Binary.fromString("FOO"), "BAR", Binary.fromString("BAR")));
+        var writerTest = new ParquetWriterTest<>(MapValues.class);
+        writerTest.write(rec1, rec2);
+
+        var avroReader = writerTest.getAvroGenericRecordReader();
+        GenericRecord avroRecord = avroReader.read();
+        assertEquals(rec1.name(), avroRecord.get("name").toString());
+        assertEquals(Map.of("FOO", "BAR", "BAR", "FOO"), unByteBufferMap(avroRecord.get("values")));
+
+        avroRecord = avroReader.read();
+        assertEquals(rec2.name(), avroRecord.get("name").toString());
+        assertEquals(Map.of("FOO", "FOO", "BAR", "BAR"), unByteBufferMap(avroRecord.get("values")));
 
         var carpetReader = writerTest.getCarpetReader();
         assertEquals(rec1, carpetReader.read());
@@ -458,4 +624,35 @@ class WriteRecordModelWriterMapTest {
         return map;
     }
 
+    private Object unByteBufferMap(Object obj) throws IOException {
+        if (obj instanceof Map<?, ?> map) {
+            Map<Object, Object> res = new HashMap<>();
+            for (var e : map.entrySet()) {
+                Object key = e.getKey() instanceof Utf8 u ? u.toString() : e.getKey();
+                Object value = e.getValue() instanceof ByteBuffer u ? new String(u.array(), "UTF-8") : e.getValue();
+                if (value instanceof Map) {
+                    value = unByteBufferMap(value);
+                }
+                res.put(key, value);
+            }
+            return res;
+        }
+        return obj;
+    }
+
+    private Object unUtf8Map(Object obj) {
+        if (obj instanceof Map<?, ?> map) {
+            Map<Object, Object> res = new HashMap<>();
+            for (var e : map.entrySet()) {
+                Object key = e.getKey() instanceof Utf8 u ? u.toString() : e.getKey();
+                Object value = e.getValue() instanceof Utf8 u ? u.toString() : e.getValue();
+                if (value instanceof Map) {
+                    value = unUtf8Map(value);
+                }
+                res.put(key, value);
+            }
+            return res;
+        }
+        return obj;
+    }
 }

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
@@ -526,6 +526,28 @@ class WriteRecordModelWriterTest {
         }
 
         @Test
+        void justBinaryObject() throws IOException {
+
+            record JustBinaryObject(Binary value) {
+            }
+
+            var mapper = writeRecordModel(JustBinaryObject.class)
+                    .withField("value", BINARY, JustBinaryObject::value);
+
+            byte[] byteArray = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            var rec = new JustBinaryObject(Binary.fromConstantByteArray(byteArray));
+            var writerTest = new ParquetWriterTest<>(JustBinaryObject.class);
+            writerTest.write(mapper, rec);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            ByteBuffer asByteBuffer = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec.value, Binary.fromReusedByteBuffer(asByteBuffer));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec, carpetReader.read());
+        }
+
+        @Test
         void enumObject() throws IOException {
 
             record EnumObject(Category value) {

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -62,6 +63,8 @@ import org.junit.jupiter.api.Test;
 import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.RecordTypeConversionException;
 import com.jerolba.carpet.TimeUnit;
+import com.jerolba.carpet.annotation.ParquetBson;
+import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.model.FieldTypes;
 import com.jerolba.carpet.model.WriteRecordModelType;
@@ -444,6 +447,85 @@ class WriteRecordModelWriterTest {
         }
 
         @Test
+        void jsonAsStringObject() throws IOException {
+
+            record JsonAsStringObject(@ParquetJson String value) {
+            }
+
+            var mapper = writeRecordModel(JsonAsStringObject.class)
+                    .withField("value", STRING.asJson(), JsonAsStringObject::value);
+
+            var rec1 = new JsonAsStringObject("{\"city\": \"Madrid\"}");
+            var rec2 = new JsonAsStringObject("{\"city\": \"Zaragoza\"}");
+            var writerTest = new ParquetWriterTest<>(JsonAsStringObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            ByteBuffer asByteBuffer1 = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec1.value, new String(asByteBuffer1.array()));
+            ByteBuffer asByteBuffer2 = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec2.value, new String(asByteBuffer2.array()));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void jsonAsBinaryObject() throws IOException {
+
+            record JsonAsBinaryObject(@ParquetJson Binary value) {
+            }
+
+            var mapper = writeRecordModel(JsonAsBinaryObject.class)
+                    .withField("value", BINARY.asJson(), JsonAsBinaryObject::value);
+
+            var rec1 = new JsonAsBinaryObject(Binary.fromString("{\"city\": \"Madrid\"}"));
+            var rec2 = new JsonAsBinaryObject(Binary.fromString("{\"city\": \"Zaragoza\"}"));
+            var writerTest = new ParquetWriterTest<>(JsonAsBinaryObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            ByteBuffer asByteBuffer1 = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec1.value, Binary.fromReusedByteBuffer(asByteBuffer1));
+            ByteBuffer asByteBuffer2 = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec2.value, Binary.fromReusedByteBuffer(asByteBuffer2));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void bsonAsBinaryObject() throws IOException {
+
+            record BsonAsBinaryObject(@ParquetBson Binary value) {
+            }
+
+            var mapper = writeRecordModel(BsonAsBinaryObject.class)
+                    .withField("value", BINARY.asBson(), BsonAsBinaryObject::value);
+
+            byte[] bson = new byte[] {
+                    0x16, 0x00, 0x00, 0x00, // Total lenght (22 bytes) in little-endian
+                    0x02, // Data type: String (0x02)
+                    0x63, 0x69, 0x74, 0x79, 0x00, // "city" + null terminator
+                    0x07, 0x00, 0x00, 0x00, // string lenght (7 bytes) in little-endian
+                    0x4D, 0x61, 0x64, 0x72, 0x69, 0x64, 0x00, // "Madrid" + null terminator
+                    0x00 // document terminator
+            };
+            var rec = new BsonAsBinaryObject(Binary.fromConstantByteArray(bson));
+            var writerTest = new ParquetWriterTest<>(BsonAsBinaryObject.class);
+            writerTest.write(mapper, rec);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            ByteBuffer asByteBuffer = (ByteBuffer) avroReader.read().get("value");
+            assertEquals(rec.value, Binary.fromReusedByteBuffer(asByteBuffer));
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec, carpetReader.read());
+        }
+
+        @Test
         void enumObject() throws IOException {
 
             record EnumObject(Category value) {
@@ -464,6 +546,36 @@ class WriteRecordModelWriterTest {
             var carpetReader = writerTest.getCarpetReader();
             assertEquals(rec1, carpetReader.read());
             assertEquals(rec2, carpetReader.read());
+        }
+
+        @Test
+        void enumAsStringObject() throws IOException {
+
+            record EnumObject(Category value) {
+            }
+
+            var mapper = writeRecordModel(EnumObject.class)
+                    .withField("value", ENUM.ofType(Category.class).asString(), EnumObject::value);
+
+            var rec1 = new EnumObject(Category.one);
+            var rec2 = new EnumObject(Category.two);
+            var writerTest = new ParquetWriterTest<>(EnumObject.class);
+            writerTest.write(mapper, rec1, rec2);
+
+            var avroReader = writerTest.getAvroGenericRecordReader();
+            assertEquals(rec1.value.name(), avroReader.read().get("value").toString());
+            assertEquals(rec2.value.name(), avroReader.read().get("value").toString());
+
+            var carpetReader = writerTest.getCarpetReader();
+            assertEquals(rec1, carpetReader.read());
+            assertEquals(rec2, carpetReader.read());
+
+            record EnumStringObject(String value) {
+            }
+
+            var carpetReaderString = writerTest.getCarpetReader(EnumStringObject.class);
+            assertEquals(new EnumStringObject("one"), carpetReaderString.read());
+            assertEquals(new EnumStringObject("two"), carpetReaderString.read());
         }
 
         @Test

--- a/carpet-samples/build.gradle
+++ b/carpet-samples/build.gradle
@@ -7,6 +7,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17    
 }
 
 repositories {

--- a/carpet-samples/build.gradle
+++ b/carpet-samples/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     implementation project(':carpet-record')
-
+    testImplementation "org.mongodb:bson:5.4.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.jerolba.carpet
-version = 0.3.0
+version = 0.4.0-SNAPSHOT
 
 parquetVersion = 1.15.1
 hadoopVersion = 3.4.1


### PR DESCRIPTION
* Add new type: parquet Binary
* Modify String and Enum model types to support changing their target LogicalType
* Add new annotation @ParquetJson, @ParquetBson, @ParquetString and @ParquetEnum, that can modify a String or Binary target type:
   * `@ParquetJson String` will generate a binary json type in parquet schema
   * `@ParquetBson Binary`will generate a binary bson type in parquet schema
* Refactor `Parameterized` to support annotations reflection
* Refactor schema generation and matching to isolate logic by type and make it reusable