### PR TITLE
#83 Improve performance reading LocalDateTime values

### DIFF
--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeConverter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeConverter.java
@@ -26,6 +26,7 @@ import com.jerolba.carpet.impl.read.converter.LocalDateTimeRead.LongToLocalDateT
 
 public class LocalDateTimeConverter extends PrimitiveConverter {
 
+    private final LocalDateTimeRead localDateTimeRead = new LocalDateTimeRead();
     private final Consumer<Object> consumer;
     private final LongToLocalDateTime mapper;
     private LocalDateTime[] dict = null;
@@ -33,9 +34,9 @@ public class LocalDateTimeConverter extends PrimitiveConverter {
     public LocalDateTimeConverter(Consumer<Object> consumer, TimeUnit timeUnit) {
         this.consumer = consumer;
         this.mapper = switch (timeUnit) {
-        case MILLIS -> LocalDateTimeRead::localDateTimeFromMillisFromEpoch;
-        case MICROS -> LocalDateTimeRead::localDateTimeFromMicrosFromEpoch;
-        case NANOS -> LocalDateTimeRead::localDateTimeFromNanosFromEpoch;
+        case MILLIS -> localDateTimeRead::localDateTimeFromMillisFromEpoch;
+        case MICROS -> localDateTimeRead::localDateTimeFromMicrosFromEpoch;
+        case NANOS -> localDateTimeRead::localDateTimeFromNanosFromEpoch;
         };
     }
 

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeRead.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/read/converter/LocalDateTimeRead.java
@@ -18,6 +18,7 @@ package com.jerolba.carpet.impl.read.converter;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.zone.ZoneRules;
 
 public class LocalDateTimeRead {
 
@@ -26,23 +27,26 @@ public class LocalDateTimeRead {
         LocalDateTime map(long timeFromEpoch);
     }
 
-    public static LocalDateTime localDateTimeFromMillisFromEpoch(long millisFromEpoch) {
+    private final ZoneRules rules = ZoneOffset.UTC.getRules();
+
+    public LocalDateTime localDateTimeFromMillisFromEpoch(long millisFromEpoch) {
         Instant instant = InstantRead.instantFromMillisFromEpoch(millisFromEpoch);
         return localDateTimeInUTC(instant);
     }
 
-    public static LocalDateTime localDateTimeFromMicrosFromEpoch(long microsFromEpoch) {
+    public LocalDateTime localDateTimeFromMicrosFromEpoch(long microsFromEpoch) {
         Instant instant = InstantRead.instantFromMicrosFromEpoch(microsFromEpoch);
         return localDateTimeInUTC(instant);
     }
 
-    public static LocalDateTime localDateTimeFromNanosFromEpoch(long nanosFromEpoch) {
+    public LocalDateTime localDateTimeFromNanosFromEpoch(long nanosFromEpoch) {
         Instant instant = InstantRead.instantFromNanosFromEpoch(nanosFromEpoch);
         return localDateTimeInUTC(instant);
     }
 
-    private static LocalDateTime localDateTimeInUTC(Instant instant) {
-        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    private LocalDateTime localDateTimeInUTC(Instant instant) {
+        ZoneOffset offset = rules.getOffset(instant);
+        return LocalDateTime.ofEpochSecond(instant.getEpochSecond(), instant.getNano(), offset);
     }
 
 }


### PR DESCRIPTION
Avoid repeated instantiation of `ZoneOffset.UTC.getRules()`

Closes GH-83