### PR TITLE
 #105 #108 Add geospatial types to write model

### DIFF
--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/FieldTypeInspect.java
@@ -16,6 +16,8 @@
 package com.jerolba.carpet.impl.write;
 
 import com.jerolba.carpet.model.BigDecimalType;
+import com.jerolba.carpet.model.BinaryAliasedType;
+import com.jerolba.carpet.model.BinaryGeospatialType;
 import com.jerolba.carpet.model.BinaryLogicalType;
 import com.jerolba.carpet.model.BinaryType;
 import com.jerolba.carpet.model.BooleanType;
@@ -24,6 +26,7 @@ import com.jerolba.carpet.model.DoubleType;
 import com.jerolba.carpet.model.EnumType;
 import com.jerolba.carpet.model.FieldType;
 import com.jerolba.carpet.model.FloatType;
+import com.jerolba.carpet.model.GeometryType;
 import com.jerolba.carpet.model.InstantType;
 import com.jerolba.carpet.model.IntegerType;
 import com.jerolba.carpet.model.ListType;
@@ -82,6 +85,14 @@ class FieldTypeInspect {
         return fieldType instanceof BinaryType;
     }
 
+    public boolean isBinaryGeospatial() {
+        return fieldType instanceof BinaryGeospatialType;
+    }
+
+    public boolean isJtsGeometry() {
+        return fieldType instanceof GeometryType;
+    }
+
     public boolean isEnum() {
         return fieldType instanceof EnumType;
     }
@@ -123,15 +134,31 @@ class FieldTypeInspect {
     }
 
     public BinaryLogicalType binaryLogicalType() {
-        if (fieldType instanceof BinaryType binary) {
-            return binary.logicalType();
+        if (fieldType instanceof BinaryAliasedType binaryAliased) {
+            return binaryAliased.logicalType();
         } else if (fieldType instanceof StringType string) {
             return string.logicalType();
         } else if (fieldType instanceof EnumType enumType) {
             return enumType.logicalType();
+        } else if (fieldType instanceof BinaryType) {
+            return null;
         } else {
             throw new IllegalStateException("Field type is not a binary type");
         }
+    }
+
+    public GeometryType geometryType() {
+        if (fieldType instanceof GeometryType geometry) {
+            return geometry;
+        }
+        throw new IllegalStateException("Field type is not a geometry type");
+    }
+
+    public BinaryGeospatialType binaryGeospatialType() {
+        if (fieldType instanceof BinaryGeospatialType geospatial) {
+            return geospatial;
+        }
+        throw new IllegalStateException("Field type is not a BinaryGeospatialType");
     }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/ModelFieldsWriter.java
@@ -16,6 +16,7 @@
 package com.jerolba.carpet.impl.write;
 
 import static com.jerolba.carpet.impl.write.BigDecimalWrite.buildDecimalConfig;
+import static com.jerolba.carpet.impl.write.GeometryWrite.geometryCosumer;
 import static com.jerolba.carpet.impl.write.TimeWrite.instantCosumer;
 import static com.jerolba.carpet.impl.write.TimeWrite.localDateTimeConsumer;
 import static com.jerolba.carpet.impl.write.TimeWrite.localTimeConsumer;
@@ -68,7 +69,7 @@ class ModelFieldsWriter {
         if (type.isShort() || type.isByte()) {
             return (consumer, v) -> consumer.addInteger(((Number) v).intValue());
         }
-        if (type.isBinary()) {
+        if (type.isBinary() || type.isBinaryGeospatial()) {
             return (consumer, v) -> consumer.addBinary((Binary) v);
         }
         if (fieldType instanceof EnumType enumType) {
@@ -95,6 +96,9 @@ class ModelFieldsWriter {
             var config = buildDecimalConfig(bigDecimalType.precision(), bigDecimalType.scale(),
                     bigDecimalType.roundingMode(), carpetConfiguration.decimalConfig());
             return new BigDecimalWrite(config)::write;
+        }
+        if (type.isJtsGeometry()) {
+            return geometryCosumer();
         }
         if (fieldType instanceof WriteRecordModelType<?> recordType) {
             var recordWriter = new WriteRecordModelWriter(recordConsumer, recordType, carpetConfiguration);

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryAliasedType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryAliasedType.java
@@ -15,16 +15,22 @@
  */
 package com.jerolba.carpet.model;
 
-public sealed interface FieldType
-        permits BooleanType, ByteType, ShortType, IntegerType,
-        LongType, FloatType, DoubleType, StringType, BinaryType, EnumType,
-        UuidType, BigDecimalType, LocalDateType, LocalTimeType,
-        LocalDateTimeType, InstantType, GeometryType,
-        CollectionType, ListType, SetType, MapType,
-        WriteRecordModelType {
+public final class BinaryAliasedType extends BinaryType {
 
-    boolean isNotNull();
+    private final BinaryLogicalType logicalType;
 
-    Class<?> getClassType();
+    BinaryAliasedType(boolean isNotNull, BinaryLogicalType logicalType) {
+        super(isNotNull);
+        this.logicalType = logicalType;
+    }
+
+    @Override
+    public BinaryAliasedType notNull() {
+        return new BinaryAliasedType(true, logicalType);
+    }
+
+    public BinaryLogicalType logicalType() {
+        return logicalType;
+    }
 
 }

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryGeospatialType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryGeospatialType.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
+
+import com.jerolba.carpet.model.GeometryType.GeospatialType;
+
+public final class BinaryGeospatialType extends BinaryType {
+
+    private final GeospatialType geospatialType;
+    private final String crs;
+    private final EdgeInterpolationAlgorithm algorithm;
+
+    BinaryGeospatialType(boolean isNotNull, GeospatialType geospatialType, String crs,
+            EdgeInterpolationAlgorithm algorithm) {
+        super(isNotNull);
+        this.geospatialType = geospatialType;
+        this.crs = crs;
+        this.algorithm = algorithm;
+    }
+
+    @Override
+    public BinaryGeospatialType notNull() {
+        return new BinaryGeospatialType(true, geospatialType, crs, algorithm);
+    }
+
+    public GeospatialType geospatialType() {
+        return geospatialType;
+    }
+
+    public String crs() {
+        return crs;
+    }
+
+    public EdgeInterpolationAlgorithm algorithm() {
+        return algorithm;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/BinaryType.java
@@ -15,28 +15,50 @@
  */
 package com.jerolba.carpet.model;
 
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.io.api.Binary;
 
-public record BinaryType(boolean isNotNull, BinaryLogicalType logicalType) implements FieldType {
+import com.jerolba.carpet.model.GeometryType.GeospatialType;
+
+public sealed class BinaryType implements FieldType permits BinaryGeospatialType, BinaryAliasedType {
+
+    private final boolean isNotNull;
+
+    BinaryType(boolean isNotNull) {
+        this.isNotNull = isNotNull;
+    }
+
+    @Override
+    public boolean isNotNull() {
+        return isNotNull;
+    }
 
     public BinaryType notNull() {
-        return new BinaryType(true, logicalType);
+        return new BinaryType(true);
     }
 
-    public BinaryType asString() {
-        return new BinaryType(isNotNull, BinaryLogicalType.STRING);
+    public BinaryAliasedType asString() {
+        return new BinaryAliasedType(isNotNull, BinaryLogicalType.STRING);
     }
 
-    public BinaryType asEnum() {
-        return new BinaryType(isNotNull, BinaryLogicalType.ENUM);
+    public BinaryAliasedType asEnum() {
+        return new BinaryAliasedType(isNotNull, BinaryLogicalType.ENUM);
     }
 
-    public BinaryType asJson() {
-        return new BinaryType(isNotNull, BinaryLogicalType.JSON);
+    public BinaryAliasedType asJson() {
+        return new BinaryAliasedType(isNotNull, BinaryLogicalType.JSON);
     }
 
-    public BinaryType asBson() {
-        return new BinaryType(isNotNull, BinaryLogicalType.BSON);
+    public BinaryAliasedType asBson() {
+        return new BinaryAliasedType(isNotNull, BinaryLogicalType.BSON);
+    }
+
+    public BinaryGeospatialType asParquetGeometry(String crs) {
+        return new BinaryGeospatialType(isNotNull, GeospatialType.GEOMETRY, crs, null);
+    }
+
+    public BinaryGeospatialType asParquetGeography(String crs, EdgeInterpolationAlgorithm algorithm) {
+        return new BinaryGeospatialType(isNotNull, GeospatialType.GEOGRAPHY, crs, algorithm);
     }
 
     @Override

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/FieldTypes.java
@@ -25,8 +25,9 @@ public class FieldTypes {
     public static final FloatType FLOAT = new FloatType(false);
     public static final DoubleType DOUBLE = new DoubleType(false);
     public static final StringType STRING = new StringType(false, null);
-    public static final BinaryType BINARY = new BinaryType(false, null);
+    public static final BinaryType BINARY = new BinaryType(false);
     public static final EnumTypeBuilder ENUM = new EnumTypeBuilder();
+    public static final GeometryTypeBuilder GEOMETRY = new GeometryTypeBuilder();
     public static final UuidType UUID = new UuidType(false);
     public static final BigDecimalType BIG_DECIMAL = new BigDecimalType(false, null, null, null);
     public static final LocalDateType LOCAL_DATE = new LocalDateType(false);

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/GeometryType.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/GeometryType.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
+import org.locationtech.jts.geom.Geometry;
+
+public final class GeometryType implements FieldType {
+
+    public enum GeospatialType {
+        GEOMETRY, GEOGRAPHY
+    }
+
+    private final boolean isNotNull;
+    private final GeospatialType geospatialType;
+    private final String crs;
+    private final EdgeInterpolationAlgorithm algorithm;
+
+    GeometryType(boolean isNotNull, GeospatialType geospatialType, String crs, EdgeInterpolationAlgorithm algorithm) {
+        this.isNotNull = isNotNull;
+        this.geospatialType = geospatialType;
+        this.crs = crs;
+        this.algorithm = algorithm;
+    }
+
+    public GeometryType notNull() {
+        return new GeometryType(true, geospatialType, crs, algorithm);
+    }
+
+    @Override
+    public boolean isNotNull() {
+        return isNotNull;
+    }
+
+    public GeospatialType geospatialType() {
+        return geospatialType;
+    }
+
+    public String crs() {
+        return crs;
+    }
+
+    public EdgeInterpolationAlgorithm algorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public Class<?> getClassType() {
+        return Geometry.class;
+    }
+
+}

--- a/carpet-record/src/main/java/com/jerolba/carpet/model/GeometryTypeBuilder.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/model/GeometryTypeBuilder.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.model;
+
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
+
+import com.jerolba.carpet.model.GeometryType.GeospatialType;
+
+public class GeometryTypeBuilder {
+
+    private final boolean notNull;
+
+    GeometryTypeBuilder() {
+        this(false);
+    }
+
+    private GeometryTypeBuilder(boolean notNull) {
+        this.notNull = notNull;
+    }
+
+    public GeometryTypeBuilder notNull() {
+        return new GeometryTypeBuilder(true);
+    }
+
+    public GeometryType asParquetGeometry(String crs) {
+        return new GeometryType(notNull, GeospatialType.GEOMETRY, crs, null);
+    }
+
+    public GeometryType asParquetGeography(String crs, EdgeInterpolationAlgorithm algorithm) {
+        return new GeometryType(notNull, GeospatialType.GEOGRAPHY, crs, algorithm);
+    }
+
+}

--- a/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/impl/write/JavaRecordMapper2SchemaTest.java
@@ -46,6 +46,9 @@ import com.jerolba.carpet.annotation.Alias;
 import com.jerolba.carpet.annotation.NotNull;
 import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetGeography;
+import com.jerolba.carpet.annotation.ParquetGeography.EdgeAlgorithm;
+import com.jerolba.carpet.annotation.ParquetGeometry;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.annotation.ParquetString;
 import com.jerolba.carpet.annotation.PrecisionScale;
@@ -252,6 +255,130 @@ class JavaRecordMapper2SchemaTest {
                     message BsonRecord {
                       required int64 id;
                       required binary value (BSON);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class GeometryType {
+
+        @Test
+        void geometryFieldFromBinaryWithoutCsr() {
+            record GeometryRecord(long id, @ParquetGeometry Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeometryRecord.class);
+            String expected = """
+                    message GeometryRecord {
+                      required int64 id;
+                      optional binary value (GEOMETRY);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullGeometryFieldFromBinary() {
+            record GeometryRecord(long id, @ParquetGeometry @NotNull Binary value) {
+            }
+
+            MessageType schema = class2Model2Schema(GeometryRecord.class);
+            String expected = """
+                    message GeometryRecord {
+                      required int64 id;
+                      required binary value (GEOMETRY);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void geometryFieldFromBinaryWithSridCsr() {
+            record GeometryRecord(long id, @ParquetGeometry("srid:5070") Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeometryRecord.class);
+            String expected = """
+                    message GeometryRecord {
+                      required int64 id;
+                      optional binary value (GEOMETRY(srid:5070));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void geometryFieldFromBinaryWithProjjsonCsr() {
+            record GeometryRecord(long id, @ParquetGeometry("projjson:projjson_epsg_5070") Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeometryRecord.class);
+            String expected = """
+                    message GeometryRecord {
+                      required int64 id;
+                      optional binary value (GEOMETRY(projjson:projjson_epsg_5070));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+    }
+
+    @Nested
+    class GeographyType {
+
+        @Test
+        void geographyFieldFromBinaryWithoutAnnotatedValues() {
+            record GeographyRecord(long id, @ParquetGeography Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeographyRecord.class);
+            String expected = """
+                    message GeographyRecord {
+                      required int64 id;
+                      optional binary value (GEOGRAPHY);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void notNullGeographyFieldFromBinary() {
+            record GeographyRecord(long id, @ParquetGeography @NotNull Binary value) {
+            }
+
+            MessageType schema = class2Model2Schema(GeographyRecord.class);
+            String expected = """
+                    message GeographyRecord {
+                      required int64 id;
+                      required binary value (GEOGRAPHY);
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void geographyFieldFromBinaryWithSridCsrConfiguresDefaultAlgorithm() {
+            record GeographyRecord(long id, @ParquetGeography(crs = "srid:5070") Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeographyRecord.class);
+            String expected = """
+                    message GeographyRecord {
+                      required int64 id;
+                      optional binary value (GEOGRAPHY(srid:5070,SPHERICAL));
+                    }
+                    """;
+            assertEquals(expected, schema.toString());
+        }
+
+        @Test
+        void geographyFieldFromBinaryWithAlgorithmConfiguresDefaultCrs() {
+            record GeographyRecord(long id, @ParquetGeography(algorithm = EdgeAlgorithm.ANDOYER) Binary value) {
+            }
+            MessageType schema = class2Model2Schema(GeographyRecord.class);
+            String expected = """
+                    message GeographyRecord {
+                      required int64 id;
+                      optional binary value (GEOGRAPHY(OGC:CRS84,ANDOYER));
                     }
                     """;
             assertEquals(expected, schema.toString());

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/WriteRecordModelWriterCollectionTwoLevelTest.java
@@ -21,6 +21,7 @@ import static com.jerolba.carpet.model.FieldTypes.BINARY;
 import static com.jerolba.carpet.model.FieldTypes.BOOLEAN;
 import static com.jerolba.carpet.model.FieldTypes.DOUBLE;
 import static com.jerolba.carpet.model.FieldTypes.ENUM;
+import static com.jerolba.carpet.model.FieldTypes.GEOMETRY;
 import static com.jerolba.carpet.model.FieldTypes.INTEGER;
 import static com.jerolba.carpet.model.FieldTypes.LIST;
 import static com.jerolba.carpet.model.FieldTypes.MAP;
@@ -32,21 +33,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.io.api.Binary;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKBWriter;
 
 import com.jerolba.carpet.ParquetWriterTest;
 import com.jerolba.carpet.annotation.ParquetBson;
 import com.jerolba.carpet.annotation.ParquetEnum;
+import com.jerolba.carpet.annotation.ParquetGeography;
+import com.jerolba.carpet.annotation.ParquetGeometry;
 import com.jerolba.carpet.annotation.ParquetJson;
 import com.jerolba.carpet.writer.CarpetWriterCollectionThreeLevelTest.Category;
 
 class WriteRecordModelWriterCollectionTwoLevelTest {
+
+    private final GeometryFactory geomFactory = new GeometryFactory();
+    private final WKBWriter wkbWriter = new WKBWriter();
 
     @Test
     void simpleTypeCollection() throws IOException {
@@ -235,6 +249,179 @@ class WriteRecordModelWriterCollectionTwoLevelTest {
 
         try (var carpetReader = writerTest.getCarpetReader()) {
             assertEquals(rec, carpetReader.read());
+        }
+    }
+
+    @Test
+    void simpleGeometryCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetGeometry Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values", LIST.ofType(BINARY.asParquetGeometry("OGC:CRS84")), SimpleTypeCollection::values);
+
+        Binary point1 = Binary
+                .fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(1.0, 1.0))));
+        Binary point2 = Binary
+                .fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(2.0, 2.0))));
+
+        var rec = new SimpleTypeCollection("foo", List.of(point1, point2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        try (var avroReader = writerTest.getAvroGenericRecordReader()) {
+            GenericRecord avroRecord = avroReader.read();
+            assertEquals(rec.name(), avroRecord.get("name").toString());
+
+            List<ByteBuffer> ids = (List<ByteBuffer>) avroRecord.get("values");
+            assertEquals(2, ids.size());
+            // Avro does not support Geometry
+            byte[] fromAvro1 = ids.get(0).array();
+            assertEquals(point1.length(), fromAvro1.length);
+            for (int i = 0; i < point1.length(); i++) {
+                assertEquals(point1.getBytes()[i], fromAvro1[i]);
+            }
+            byte[] fromAvro2 = ids.get(1).array();
+            assertEquals(point2.length(), fromAvro2.length);
+            for (int i = 0; i < point2.length(); i++) {
+                assertEquals(point2.getBytes()[i], fromAvro2[i]);
+            }
+        }
+        try (var carpetReader = writerTest.getCarpetReader()) {
+            assertEquals(rec, carpetReader.read());
+        }
+    }
+
+    @Test
+    void simpleGeometryJtsCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetGeometry Geometry> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values",
+                        LIST.ofType(GEOMETRY.asParquetGeometry("OGC:CRS84")), SimpleTypeCollection::values);
+
+        Point point1 = geomFactory.createPoint(new Coordinate(1.0, 1.0));
+        Point point2 = geomFactory.createPoint(new Coordinate(2.0, 2.0));
+
+        var rec = new SimpleTypeCollection("foo", List.of(point1, point2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        try (var avroReader = writerTest.getAvroGenericRecordReader()) {
+            GenericRecord avroRecord = avroReader.read();
+            assertEquals(rec.name(), avroRecord.get("name").toString());
+
+            List<ByteBuffer> ids = (List<ByteBuffer>) avroRecord.get("values");
+            assertEquals(2, ids.size());
+            // Avro does not support Geometry
+            byte[] fromAvro1 = ids.get(0).array();
+            byte[] wkb1 = wkbWriter.write(point1);
+            assertEquals(wkb1.length, fromAvro1.length);
+            for (int i = 0; i < wkb1.length; i++) {
+                assertEquals(wkb1[i], fromAvro1[i]);
+            }
+            byte[] fromAvro2 = ids.get(1).array();
+            byte[] wkb2 = wkbWriter.write(point2);
+            assertEquals(wkb2.length, fromAvro2.length);
+            for (int i = 0; i < wkb2.length; i++) {
+                assertEquals(wkb2[i], fromAvro2[i]);
+            }
+        }
+        try (var carpetReader = writerTest.getCarpetReader()) {
+            assertEquals(rec, carpetReader.read());
+        }
+    }
+
+    @Test
+    void simpleGeographyCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetGeography Binary> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values",
+                        LIST.ofType(BINARY.asParquetGeography("OGC:CRS84", EdgeInterpolationAlgorithm.SPHERICAL)),
+                        SimpleTypeCollection::values);
+
+        Binary point1 = Binary
+                .fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(1.0, 1.0))));
+        Binary point2 = Binary
+                .fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(2.0, 2.0))));
+
+        var rec = new SimpleTypeCollection("foo", List.of(point1, point2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        try (var avroReader = writerTest.getAvroGenericRecordReader()) {
+            GenericRecord avroRecord = avroReader.read();
+            assertEquals(rec.name(), avroRecord.get("name").toString());
+
+            List<ByteBuffer> ids = (List<ByteBuffer>) avroRecord.get("values");
+            assertEquals(2, ids.size());
+            // Avro does not support Geography
+            byte[] fromAvro1 = ids.get(0).array();
+            assertEquals(point1.length(), fromAvro1.length);
+            for (int i = 0; i < point1.length(); i++) {
+                assertEquals(point1.getBytes()[i], fromAvro1[i]);
+            }
+            byte[] fromAvro2 = ids.get(1).array();
+            assertEquals(point2.length(), fromAvro2.length);
+            for (int i = 0; i < point2.length(); i++) {
+                assertEquals(point2.getBytes()[i], fromAvro2[i]);
+            }
+        }
+        try (var carpetReader = writerTest.getCarpetReader()) {
+            assertEquals(rec, carpetReader.read());
+        }
+    }
+
+    @Test
+    void simpleGeographyJtsCollection() throws IOException {
+
+        record SimpleTypeCollection(String name, List<@ParquetGeography Geometry> values) {
+        }
+
+        var mapper = writeRecordModel(SimpleTypeCollection.class)
+                .withField("name", STRING, SimpleTypeCollection::name)
+                .withField("values",
+                        LIST.ofType(GEOMETRY.asParquetGeography("OGC:CRS84", EdgeInterpolationAlgorithm.SPHERICAL)),
+                        SimpleTypeCollection::values);
+
+        Point point1 = geomFactory.createPoint(new Coordinate(1.0, 1.0));
+        Point point2 = geomFactory.createPoint(new Coordinate(2.0, 2.0));
+
+        var rec = new SimpleTypeCollection("foo", List.of(point1, point2));
+        var writerTest = new ParquetWriterTest<>(SimpleTypeCollection.class).withLevel(TWO);
+        writerTest.write(mapper, rec);
+
+        try (var avroReader = writerTest.getAvroGenericRecordReader()) {
+            GenericRecord avroRecord = avroReader.read();
+            assertEquals(rec.name(), avroRecord.get("name").toString());
+
+            List<ByteBuffer> ids = (List<ByteBuffer>) avroRecord.get("values");
+            assertEquals(2, ids.size());
+            // Avro does not support Geometry
+            byte[] fromAvro1 = ids.get(0).array();
+            byte[] wkb1 = wkbWriter.write(point1);
+            assertEquals(wkb1.length, fromAvro1.length);
+            for (int i = 0; i < wkb1.length; i++) {
+                assertEquals(wkb1[i], fromAvro1[i]);
+            }
+            byte[] fromAvro2 = ids.get(1).array();
+            byte[] wkb2 = wkbWriter.write(point2);
+            assertEquals(wkb2.length, fromAvro2.length);
+            for (int i = 0; i < wkb2.length; i++) {
+                assertEquals(wkb2[i], fromAvro2[i]);
+            }
+            try (var carpetReader = writerTest.getCarpetReader()) {
+                assertEquals(rec, carpetReader.read());
+            }
         }
     }
 


### PR DESCRIPTION
Add Binary geospatial types and Geometry type to Write model. 

Refactor Binary type to support geospatial attributes without declaring them in main BinaryType.

Geometry type reuses @ParquetGeometry and @ParquetGeography annotations to configure crs and algorithm

