### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-gradle-project.yml
+++ b/.github/workflows/build-gradle-project.yml
@@ -1,4 +1,6 @@
 name: Java Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jerolba/parquet-carpet/security/code-scanning/1](https://github.com/jerolba/parquet-carpet/security/code-scanning/1)

To fix the problem, you should explicitly limit the permissions available to the workflow or job, following the principle of least privilege. In this workflow, add a `permissions` block at the top level (applies to all jobs), minimally setting `contents: read`. This ensures that GITHUB_TOKEN is only granted read access to repository contents, preventing any unintended modifications. Insert the following block directly below the workflow `name:` or above the `on:` block. If in future there’s a requirement to grant further permissions (e.g., `pull-requests: write`), add them explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
