### PR TITLE
#57 Improve Write Model tests coverage

### DIFF
--- a/.github/workflows/build-gradle-project-write-model.yml
+++ b/.github/workflows/build-gradle-project-write-model.yml
@@ -29,7 +29,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Test Reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-reports-write-model

--- a/.github/workflows/build-gradle-project-write-model.yml
+++ b/.github/workflows/build-gradle-project-write-model.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Run tests with Write Model
       run: ./gradlew build -Dparquet.carpet.useJavaRecord2WriteModel=true
       continue-on-error: true
+      id: gradle-build
 
     - name: Upload Test Reports
       uses: actions/upload-artifact@v4
@@ -36,4 +37,8 @@ jobs:
         path: |
           **/build/reports/tests/**/*
         retention-days: 30
+
+    - name: Fail workflow if build failed
+      if: steps.gradle-build.outcome == 'failure'
+      run: exit 1
 

--- a/.github/workflows/build-gradle-project-write-model.yml
+++ b/.github/workflows/build-gradle-project-write-model.yml
@@ -1,6 +1,8 @@
 name: Java Build Write Model
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 on:
   push:
@@ -24,4 +26,14 @@ jobs:
 
     - name: Run tests with Write Model
       run: ./gradlew build -Dparquet.carpet.useJavaRecord2WriteModel=true
+      continue-on-error: true
+
+    - name: Upload Test Reports
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: test-reports-write-model
+        path: |
+          **/build/reports/tests/**/*
+        retention-days: 30
 

--- a/.github/workflows/build-gradle-project-write-model.yml
+++ b/.github/workflows/build-gradle-project-write-model.yml
@@ -1,4 +1,4 @@
-name: Java Build
+name: Java Build Write Model
 permissions:
   contents: read
 
@@ -22,10 +22,6 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
 
-    - name: Run build with Gradle Wrapper
-      run: ./gradlew build jacocoTestReport
+    - name: Run tests with Write Model
+      run: ./gradlew build -Dparquet.carpet.useJavaRecord2WriteModel=true
 
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-gradle-project.yml
+++ b/.github/workflows/build-gradle-project.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Run build with Gradle Wrapper
       run: ./gradlew build jacocoTestReport
       continue-on-error: true
+      id: gradle-build
 
     - name: Upload Test Reports
       uses: actions/upload-artifact@v4
@@ -41,3 +42,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Fail workflow if build failed
+      if: steps.gradle-build.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/build-gradle-project.yml
+++ b/.github/workflows/build-gradle-project.yml
@@ -29,7 +29,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Test Reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-reports

--- a/.github/workflows/build-gradle-project.yml
+++ b/.github/workflows/build-gradle-project.yml
@@ -1,6 +1,8 @@
 name: Java Build
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 on:
   push:
@@ -24,6 +26,16 @@ jobs:
 
     - name: Run build with Gradle Wrapper
       run: ./gradlew build jacocoTestReport
+      continue-on-error: true
+
+    - name: Upload Test Reports
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: test-reports
+        path: |
+          **/build/reports/tests/**/*
+        retention-days: 30
 
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v5

--- a/carpet-record/build.gradle
+++ b/carpet-record/build.gradle
@@ -169,6 +169,7 @@ configurations.all {
 
 test {
     useJUnitPlatform()
+    systemProperties = System.properties as Map
 }
 
 jacocoTestReport {

--- a/carpet-record/src/main/java/com/jerolba/carpet/CarpetParquetWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/CarpetParquetWriter.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.thirdparty.com.google.common.annotations.Beta;
 import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -166,7 +165,6 @@ public class CarpetParquetWriter {
          *                          specific to Carpet and Parquet
          * @return this builder for method chaining.
          */
-        @Beta
         public Builder<T> withWriteRecordModel(WriteModelFactory<T> writeModelFactory) {
             this.writeModelFactory = writeModelFactory;
             return self();
@@ -178,7 +176,6 @@ public class CarpetParquetWriter {
          * @param rootWriteRecordModel write record model to use
          * @return this builder for method chaining.
          */
-        @Beta
         public Builder<T> withWriteRecordModel(WriteRecordModelType<T> rootWriteRecordModel) {
             if (!rootWriteRecordModel.getClassType().equals(recordClass)) {
                 throw new IllegalArgumentException("Root Write record Model class ("

--- a/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.thirdparty.com.google.common.annotations.Beta;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.compression.CompressionCodecFactory;
@@ -705,14 +704,10 @@ public class CarpetWriter<T> implements Closeable, Consumer<T> {
          * record convention. The factory receives all configuration to decide how to
          * build the WriteRecordModelType.
          *
-         * Experimental feature to support custom data models different from record,
-         * like classes or DataFrames
-         *
          * @param writeModelFactory creates WriteRecordModelType given configuration
          *                          specific to Carpet and Parquet
          * @return this builder for method chaining.
          */
-        @Beta
         public Builder<T> withWriteRecordModel(WriteModelFactory<T> writeModelFactory) {
             builder.withWriteRecordModel(writeModelFactory);
             return this;
@@ -721,13 +716,9 @@ public class CarpetWriter<T> implements Closeable, Consumer<T> {
         /**
          * Configures write data model to use, instead of default record convention.
          *
-         * Experimental feature to support custom data models different from record,
-         * like classes or DataFrames
-         *
          * @param rootWriteRecordModel write record model to use
          * @return this builder for method chaining.
          */
-        @Beta
         public Builder<T> withWriteRecordModel(WriteRecordModelType<T> rootWriteRecordModel) {
             builder.withWriteRecordModel(rootWriteRecordModel);
             return this;

--- a/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteSupportFactory.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/impl/write/WriteSupportFactory.java
@@ -34,7 +34,7 @@ public class WriteSupportFactory {
             WriteModelFactory<T> writeModelFactory) {
 
         if (writeModelFactory == null) {
-            if (parquetConfiguration.getBoolean("parquet.carpet.useJavaRecord2WriteModel", false)) {
+            if (useWriteModel(parquetConfiguration)) {
                 JavaRecord2WriteModel javaRecord2WriteModel = new JavaRecord2WriteModel(carpetConfiguration);
                 WriteRecordModelType<T> rootWriteRecordModel = javaRecord2WriteModel.createModel(recordClass);
                 return new WriteRecordModelWriteSupport<>(rootWriteRecordModel, extraMetaData, carpetConfiguration);
@@ -44,6 +44,11 @@ public class WriteSupportFactory {
         var writeConfigurationContext = new WriteConfigurationContext(carpetConfiguration, parquetConfiguration);
         WriteRecordModelType<T> rootWriteRecordModel = writeModelFactory.create(recordClass, writeConfigurationContext);
         return new WriteRecordModelWriteSupport<>(rootWriteRecordModel, extraMetaData, carpetConfiguration);
+    }
+
+    private static boolean useWriteModel(ParquetConfiguration parquetConfiguration) {
+        return parquetConfiguration.getBoolean("parquet.carpet.useJavaRecord2WriteModel", false)
+                || System.getProperty("parquet.carpet.useJavaRecord2WriteModel") != null;
     }
 
 }


### PR DESCRIPTION
Using `WriteSupportFactory` configuration, use Write Model code testing Java Record serialization tests.

Duplicate test jobs to test Java Records serialization using the configuration.

Make test reports available for analysis.

Configure CodeCov token.