### PR TITLE
Enable monitoring of written data size to support file rollover strategies

### DIFF
--- a/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
+++ b/carpet-record/src/main/java/com/jerolba/carpet/CarpetWriter.java
@@ -144,6 +144,13 @@ public class CarpetWriter<T> implements Closeable, Consumer<T> {
         }
     }
 
+    /**
+     * @return the total size of data written to the file and buffered in memory
+     */
+    public long getDataSize() {
+        return writer.getDataSize();
+    }
+
     @Override
     public void close() throws IOException {
         writer.close();

--- a/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
+++ b/carpet-record/src/test/java/com/jerolba/carpet/writer/CarpetWriterTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -2420,6 +2421,27 @@ class CarpetWriterTest {
         Map<String, String> metadata = reader.getFileMetaData().getKeyValueMetaData();
         assertEquals("someValue", metadata.get("someKey"));
         assertEquals("bar", metadata.get("foo"));
+    }
+
+
+    @Test
+    void getDataSize() throws IOException {
+
+        record SomeEntity(int value) {
+        }
+
+        var file = createTempFile("data-size", ".parquet").toFile();
+        long dataSize1;
+        long dataSize2;
+        try (var writer = new CarpetWriter<>(new FileSystemOutputFile(file), SomeEntity.class)) {
+            writer.write(new SomeEntity(1));
+            dataSize1 = writer.getDataSize();
+            writer.write(new SomeEntity(2));
+            dataSize2 = writer.getDataSize();
+        }
+        assertTrue(dataSize1 < dataSize2);
+        assertEquals(4, dataSize1);
+        assertEquals(8, dataSize2);
     }
 
     @Nested


### PR DESCRIPTION
## Problem

There is no way for `CarpetWriter` users to track how much data has been written during a write session, making it impossible to implement size-based controls like stopping writes when thresholds are exceeded or triggering file rollovers.

## What

Provide a `getDataSize()` method that returns the total bytes written to file and buffered in memory, enabling size-based write control.