### PR TITLE
 #154 Support writting s3 files

### DIFF
--- a/carpet-s3/build.gradle
+++ b/carpet-s3/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     api "org.apache.parquet:parquet-common:${parquetVersion}"
-    api "software.amazon.awssdk:s3:2.42.6"
+    api "software.amazon.awssdk:s3:${awsSdkVersion}"
 
     testImplementation project(':carpet-record')
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/LocalOutputFile.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/LocalOutputFile.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.parquet.io.PositionOutputStream;
+
+class LocalOutputFile implements S3OutputFile {
+
+    private final Path path;
+
+    LocalOutputFile(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+        if (Files.exists(path)) {
+            throw new IOException("Path already exists: " + path);
+        }
+        return createOrOverwrite(blockSizeHint);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+        return new CountedPositionOutputStream(Files.newOutputStream(path));
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+        return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+        return 0;
+    }
+
+    @Override
+    public String getPath() {
+        return path.toString();
+    }
+
+    private static class CountedPositionOutputStream extends PositionOutputStream {
+
+        private final BufferedOutputStream bos;
+        private long pos = 0;
+
+        CountedPositionOutputStream(OutputStream os) {
+            this.bos = new BufferedOutputStream(os);
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return pos;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            bos.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            bos.close();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            bos.write(b);
+            pos++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            bos.write(b, off, len);
+            pos += len;
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            bos.write(b);
+            pos += b.length;
+        }
+    }
+
+}

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFile.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFile.java
@@ -17,62 +17,45 @@ package com.jerolba.carpet.io.s3;
 
 import static com.jerolba.carpet.io.s3.CustomExecutor.createCustomExecutor;
 import static com.jerolba.carpet.io.s3.CustomExecutor.createVirtualThreadExecutorWithCommonPoolFallback;
-import static com.jerolba.carpet.io.s3.S3UrlParsing.detectLocalFilePathForReading;
+import static com.jerolba.carpet.io.s3.S3UrlParsing.detectLocalFilePathForWriting;
 import static com.jerolba.carpet.io.s3.S3UrlParsing.parses3Url;
 
 import java.nio.file.Path;
 import java.util.concurrent.Executor;
 
-import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.OutputFile;
 
 import com.jerolba.carpet.io.s3.S3UrlParsing.S3Path;
 
 import software.amazon.awssdk.services.s3.S3Client;
 
 /**
- * An extension of Parquet's {@link InputFile} interface that reads from an S3
- * object.The builder pattern is used to allow flexible configuration of the S3
- * client, bucket, key, and concurrency settings.
+ * An extension of Parquet's {@link OutputFile} interface that writes to an S3
+ * object. The builder pattern is used to allow flexible configuration of the S3
+ * client, bucket, and key.
  *
  * If no Client is provided, a default S3Client will be created using the
  * default AWS credentials provider chain and region provider chain.
  *
- * For large files data is read using parallel ranged requests to S3, with the
- * concurrency level configurable via the {@link Builder#concurrency(int)}
- * method or by providing a custom {@link Executor} via the
- * {@link Builder#executor(Executor)} method. By default, a virtual thread
- * executor with a common pool fallback is used to allow for efficient
- * concurrent reads without blocking platform threads.
+ * Data is buffered in a local temporary file and uploaded to S3 when the output
+ * stream is closed.
  *
- * If the S3 path provided to the builder is detected as a local file path (i.e.
- * it does not start with s3:// or s3a:// and points to an existing file), the
- * builder will automatically create a {@link LocalInputFile} instance that can
- * be used to read from the local file system instead of S3. This allows for
+ * If the path provided to the builder is detected as a local file path (i.e. it
+ * does not start with s3:// or s3a:// and points to a valid writable location),
+ * the builder will automatically create a {@link LocalOutputFile} instance that
+ * writes to the local file system instead of S3. "Valid" means the path is
+ * syntactically correct and its parent directory exists. This allows for
  * seamless testing and development with local files without changing the code
  * that uses the builder.
- *
- * If system property {@code carpet.s3.predownload.file} is set to true, the
- * entire S3 file will be pre-downloaded to a local temporary file before
- * reading. This can improve performance for small files or when the S3 object
- * is accessed multiple times in development, but it may not be suitable for
- * large files or production use due to of local disk usage.
- *
  */
-public interface S3InputFile extends InputFile {
+public interface S3OutputFile extends OutputFile {
 
-    /**
-     * Configuration property to enable pre-downloading the entire S3 file to a
-     * local temporary file before reading. This can improve performance for small
-     * files or when the S3 object is accessed multiple times in development.
-     */
-    public static final String CARPET_S3_PREDOWNLOAD_FILE = "carpet.s3.predownload.file";
-
-    public static S3InputFile of(String s3Path) {
+    public static S3OutputFile of(String s3Path) {
         return new Builder().s3Path(s3Path).build();
     }
 
     /**
-     * Returns a new builder for {@link S3InputFile}.
+     * Returns a new builder for {@link S3OutputFile}.
      *
      * @return a new builder
      */
@@ -81,7 +64,7 @@ public interface S3InputFile extends InputFile {
     }
 
     /**
-     * Returns a new builder for {@link S3InputFile}.
+     * Returns a new builder for {@link S3OutputFile}.
      *
      * @param s3Url the S3 URL in the format s3://bucket/key or s3a://bucket/key
      *
@@ -92,7 +75,7 @@ public interface S3InputFile extends InputFile {
     }
 
     /**
-     * Returns a new builder for {@link S3InputFile} with the specified bucket and
+     * Returns a new builder for {@link S3OutputFile} with the specified bucket and
      * key.
      *
      * @param bucket the S3 bucket name
@@ -106,8 +89,8 @@ public interface S3InputFile extends InputFile {
     public static class Builder {
 
         /**
-         * Default concurrency level for vectored read operations when using the virtual
-         * thread executor.
+         * Default concurrency level for part uploads when using the virtual thread
+         * executor.
          */
         private static final int DEFAULT_CONCURRENCY = 4;
 
@@ -121,9 +104,7 @@ public interface S3InputFile extends InputFile {
         /**
          * Configures the S3 client to use for operations. If not set, a default
          * S3Client will be created using the default AWS credentials provider chain and
-         * region provider chain. Providing a custom client allows for advanced
-         * configurations such as custom retry policies, timeouts, or using a specific
-         * AWS region.
+         * region provider chain.
          *
          * @param client the S3 client to use for operations
          * @return this builder
@@ -134,7 +115,7 @@ public interface S3InputFile extends InputFile {
         }
 
         /**
-         * Configures the S3 bucket name to read from.
+         * Configures the S3 bucket name to write to.
          *
          * @param bucket the S3 bucket name
          * @return this builder
@@ -145,7 +126,7 @@ public interface S3InputFile extends InputFile {
         }
 
         /**
-         * Configures the S3 object key to read from.
+         * Configures the S3 object key to write to.
          *
          * @param key the S3 object key
          * @return this builder
@@ -156,33 +137,11 @@ public interface S3InputFile extends InputFile {
         }
 
         /**
-         * Configures the S3 bucket and key by parsing a single S3 path string. The path
-         * should be in the format s3://bucket/key or s3a://bucket/key. This is a
-         * convenient method for setting both the bucket and key in one step, and it
-         * includes validation to ensure the path is well-formed.
+         * Configures the concurrency level for parallel part uploads. A value of 1
+         * means sequential uploads, while values greater than 1 enable concurrent
+         * uploads. Mutually exclusive with {@link #executor(Executor)}.
          *
-         * @param s3Path the S3 path string to parse for bucket and key
-         * @return this builder
-         */
-        public Builder s3Path(String s3Path) {
-            Path local = detectLocalFilePathForReading(s3Path);
-            if (local != null) {
-                this.localFilePath = local;
-            } else {
-                S3Path s3PathObj = parses3Url(s3Path);
-                this.bucket = s3PathObj.bucket();
-                this.key = s3PathObj.key();
-            }
-            return this;
-        }
-
-        /**
-         * Configures the concurrency level for vectored read operations. A value of 1
-         * means sequential reads, while values greater than 1 enable concurrent reads.
-         * Mutually exclusive with {@link #executor(Executor)}.
-         *
-         * @param concurrency the concurrency level for vectored read operations, must
-         *                    be > 0
+         * @param concurrency the concurrency level, must be > 0
          * @return this builder
          */
         public Builder concurrency(int concurrency) {
@@ -194,7 +153,7 @@ public interface S3InputFile extends InputFile {
         }
 
         /**
-         * Sets a custom executor for vectored read operations. Mutually exclusive with
+         * Sets a custom executor for parallel part uploads. Mutually exclusive with
          * {@link #concurrency(int)}.
          *
          * @param executor the executor to use
@@ -209,13 +168,39 @@ public interface S3InputFile extends InputFile {
         }
 
         /**
-         * Builds the {@link S3InputFile} instance based on the configured properties.
+         * Configures the S3 bucket and key by parsing a single S3 path string. The path
+         * should be in the format s3://bucket/key or s3a://bucket/key. This is a
+         * convenient method for setting both the bucket and key in one step, and it
+         * includes validation to ensure the path is well-formed.
          *
-         * @return the configured {@link S3InputFile} instance
+         * If the path is not an S3 URL but is a valid local file system path (its
+         * parent directory exists), the builder will fall back to creating a
+         * {@link LocalOutputFile}.
+         *
+         * @param s3Path the S3 path string to parse for bucket and key, or a local file
+         *               system path
+         * @return this builder
          */
-        public S3InputFile build() {
+        public Builder s3Path(String s3Path) {
+            Path local = detectLocalFilePathForWriting(s3Path);
+            if (local != null) {
+                this.localFilePath = local;
+            } else {
+                S3Path s3PathObj = parses3Url(s3Path);
+                this.bucket = s3PathObj.bucket();
+                this.key = s3PathObj.key();
+            }
+            return this;
+        }
+
+        /**
+         * Builds the {@link S3OutputFile} instance based on the configured properties.
+         *
+         * @return the configured {@link S3OutputFile} instance
+         */
+        public S3OutputFile build() {
             if (localFilePath != null) {
-                return new LocalInputFile(localFilePath);
+                return new LocalOutputFile(localFilePath);
             }
             if (bucket == null || bucket.isEmpty()) {
                 throw new IllegalStateException("bucket must be configured");
@@ -230,15 +215,15 @@ public interface S3InputFile extends InputFile {
             if (actualClient == null) {
                 actualClient = S3Client.create();
             }
-            Executor executor = this.executor;
+            Executor actualExecutor = this.executor;
             if (concurrency != null && concurrency > 1) {
-                executor = createCustomExecutor(concurrency);
+                actualExecutor = createCustomExecutor(concurrency);
             } else if (concurrency != null && concurrency == 1) {
-                executor = null; // Use sequential reads
+                actualExecutor = Runnable::run; // sequential: run in calling thread
             } else {
-                executor = createVirtualThreadExecutorWithCommonPoolFallback(DEFAULT_CONCURRENCY);
+                actualExecutor = createVirtualThreadExecutorWithCommonPoolFallback(DEFAULT_CONCURRENCY);
             }
-            return new S3InputFileImpl(actualClient, bucket, key, executor);
+            return new S3OutputFileImpl(actualClient, bucket, key, actualExecutor);
         }
 
     }

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFile.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFile.java
@@ -37,8 +37,11 @@ import software.amazon.awssdk.services.s3.S3Client;
  * If no Client is provided, a default S3Client will be created using the
  * default AWS credentials provider chain and region provider chain.
  *
- * Data is buffered in a local temporary file and uploaded to S3 when the output
- * stream is closed.
+ * Data is buffered in a local temporary buffer and uploaded to S3 when the
+ * buffer is full or the output stream is closed. Uploads is performed in
+ * parallel using multipart uploads, and the concurrency level can be configured
+ * via the builder or configuring a custom Executor. By default, a virtual
+ * thread executor is used for parallel uploads.
  *
  * If the path provided to the builder is detected as a local file path (i.e. it
  * does not start with s3:// or s3a:// and points to a valid writable location),

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFileImpl.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFileImpl.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import org.apache.parquet.io.PositionOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+
+class S3OutputFileImpl implements S3OutputFile {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3OutputFileImpl.class);
+
+    static final int MIN_PART_SIZE = 5 * 1024 * 1024;
+
+    private final S3Client client;
+    private final String bucket;
+    private final String key;
+    private final Executor executor;
+
+    S3OutputFileImpl(S3Client client, String bucket, String key, Executor executor) {
+        this.client = client;
+        this.bucket = bucket;
+        this.key = key;
+        this.executor = executor;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+        if (objectExists()) {
+            throw new IOException("S3 object already exists: s3://" + bucket + "/" + key);
+        }
+        return createOrOverwrite(blockSizeHint);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+        return new S3MultipartPositionOutputStream(bucket, key, client, executor);
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+        return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+        return 0;
+    }
+
+    @Override
+    public String getPath() {
+        return "s3://" + bucket + "/" + key;
+    }
+
+    private boolean objectExists() throws IOException {
+        try {
+            client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            throw new IOException("Failed to check if S3 object exists: s3://" + bucket + "/" + key, e);
+        }
+    }
+
+    private static class S3MultipartPositionOutputStream extends PositionOutputStream {
+
+        private final String bucket;
+        private final String key;
+        private final S3Client client;
+        private final Executor executor;
+        private final String uploadId;
+        private final List<CompletableFuture<CompletedPart>> futures = new ArrayList<>();
+        private ByteArrayOutputStream partBuffer = new ByteArrayOutputStream(MIN_PART_SIZE);
+        private long pos = 0;
+        private boolean closed = false;
+
+        S3MultipartPositionOutputStream(String bucket, String key, S3Client client, Executor executor)
+                throws IOException {
+            this.bucket = bucket;
+            this.key = key;
+            this.client = client;
+            this.executor = executor;
+            try {
+                this.uploadId = client.createMultipartUpload(
+                        CreateMultipartUploadRequest.builder().bucket(bucket).key(key).build())
+                        .uploadId();
+            } catch (Exception e) {
+                throw new IOException("Failed to start S3 multipart upload: s3://" + bucket + "/" + key, e);
+            }
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return pos;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            ensureOpen();
+            partBuffer.write(b);
+            pos++;
+            flushPartIfNeeded();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            ensureOpen();
+            partBuffer.write(b, off, len);
+            pos += len;
+            flushPartIfNeeded();
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            ensureOpen();
+            write(b, 0, b.length);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            ensureOpen();
+            // buffered in memory; actual flush happens at part boundaries.
+            // Multipart upload does not support uploading partial parts, so we only flush
+            // when a full part is ready or on close.
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                flushFinalPart();
+                completeUpload(collectCompletedParts());
+                futures.clear();
+            } catch (Exception e) {
+                abortUpload();
+                throw new IOException("Failed to complete S3 multipart upload: s3://" + bucket + "/" + key, e);
+            } finally {
+                partBuffer = null;
+                if (executor instanceof CustomExecutor customExecutor) {
+                    customExecutor.shutdown();
+                }
+            }
+        }
+
+        private void ensureOpen() throws IOException {
+            if (closed) {
+                throw new IOException("Stream closed");
+            }
+        }
+
+        private void flushPartIfNeeded() {
+            if (partBuffer.size() >= MIN_PART_SIZE) {
+                uploadPart();
+            }
+        }
+
+        private void flushFinalPart() {
+            if (partBuffer.size() > 0) {
+                uploadPart();
+            }
+        }
+
+        private void uploadPart() {
+            int partNumber = futures.size() + 1;
+            byte[] data = partBuffer.toByteArray();
+            partBuffer.reset();
+            long partStartPos = pos - data.length;
+            CompletableFuture<CompletedPart> future = CompletableFuture.supplyAsync(
+                    () -> uploadPartS3(partNumber, partStartPos, data), executor);
+            futures.add(future);
+        }
+
+        private CompletedPart uploadPartS3(int partNumber, long startPos, byte[] data) {
+            logger.debug("Uploading part {} to s3://{}/{}: position={}, length={}",
+                    partNumber, bucket, key, startPos, data.length);
+            long startTime = System.nanoTime();
+            UploadPartResponse response = client.uploadPart(
+                    UploadPartRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .uploadId(uploadId)
+                            .partNumber(partNumber)
+                            .contentLength((long) data.length)
+                            .build(),
+                    RequestBody.fromBytes(data));
+            long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
+            logger.debug("Uploaded part {} to s3://{}/{}: position={}, length={} bytes in {} ms",
+                    partNumber, bucket, key, startPos, data.length, elapsedMs);
+            return CompletedPart.builder()
+                    .partNumber(partNumber)
+                    .eTag(response.eTag())
+                    .build();
+        }
+
+        /**
+         * Waits for all submitted part uploads to complete and collects the results in
+         * part-number order. This is the guarantee that all parts have been uploaded
+         * before {@link #completeUpload} is called.
+         */
+        private List<CompletedPart> collectCompletedParts() throws IOException {
+            long count = futures.stream().filter(future -> !future.isDone()).count();
+            logger.debug("Waiting for {} part uploads to complete for s3://{}/{}", count, bucket, key);
+            List<CompletedPart> parts = new ArrayList<>(futures.size());
+            for (CompletableFuture<CompletedPart> future : futures) {
+                try {
+                    parts.add(future.get());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for part upload to s3://"
+                            + bucket + "/" + key, e);
+                } catch (ExecutionException e) {
+                    throw new IOException("Part upload failed for s3://" + bucket + "/" + key, e.getCause());
+                }
+            }
+            return parts;
+        }
+
+        private void completeUpload(List<CompletedPart> parts) {
+            client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .uploadId(uploadId)
+                    .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
+                    .build());
+        }
+
+        private void abortUpload() {
+            try {
+                client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .uploadId(uploadId)
+                        .build());
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+}

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3UrlParsing.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3UrlParsing.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class S3UrlParsing {
+
+    private static final String S3A = "s3a://";
+    private static final String S3 = "s3://";
+
+    public record S3Path(String bucket, String key) {
+    }
+
+    /**
+     * Parses an S3 URL in the format s3://bucket/key or s3a://bucket/key and
+     * returns an S3Path object containing the bucket and key.
+     *
+     * @param s3Path the S3 URL to parse
+     * @return an S3Path object containing the bucket and key
+     */
+    public static S3Path parses3Url(String s3Path) {
+        if (s3Path == null || s3Path.isEmpty()) {
+            throw new IllegalArgumentException("s3Path cannot be null or empty");
+        }
+        String path = s3Path;
+        if (path.startsWith(S3)) {
+            path = path.substring(5);
+        } else if (path.startsWith(S3A)) {
+            path = path.substring(6);
+        } else {
+            throw new IllegalArgumentException("Invalid S3 path: " + s3Path + ".");
+        }
+        int slashIndex = path.indexOf('/');
+        if (slashIndex == -1) {
+            throw new IllegalArgumentException("Invalid S3 path: " + s3Path + ". Must be bucket/key");
+        }
+        String bucket = path.substring(0, slashIndex);
+        String key = path.substring(slashIndex + 1);
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("Invalid S3 path: " + s3Path + ". Key cannot be empty");
+        }
+        return new S3Path(bucket, key);
+    }
+
+    /**
+     * Detects if the given path is a local file path that exists and can be read.
+     * If the path is an S3 URL or is empty/null, this method returns null. If the
+     * path is a valid local file path that exists, it returns the corresponding
+     * Path object. If the path is a local file path that does not exist or cannot
+     * be read, it returns null.
+     *
+     * This method is used as fallback logic in the builder methods to allow users
+     * to specify either an S3 URL or a local file path when configuring input files
+     * for testing without requiring an actual S3 environment.
+     *
+     * @param s3Path the path to check
+     * @return the Path object if the path is a valid local file path, null
+     *         otherwise
+     */
+    public static Path detectLocalFilePathForReading(String s3Path) {
+        if (isS3OrEmpty(s3Path)) {
+            return null;
+        }
+        try {
+            Path path = parsePath(s3Path);
+            return Files.exists(path) ? path : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Detects if the given path is a local file path that can be written to. If the
+     * path is an S3 URL or is empty/null, this method returns null. If the path is
+     * a valid local file path that can be written to (i.e. its parent directory
+     * exists), it returns the corresponding Path object. If the path is a local
+     * file path that cannot be written to (e.g. its parent directory does not
+     * exist), it returns null.
+     *
+     * This method is used as fallback logic in the builder methods to allow users
+     * to specify either an S3 URL or a local file path when configuring output
+     * files for testing without requiring an actual S3 environment.
+     *
+     * @param path the path to check
+     * @return the Path object if the path is a valid local file path that can be
+     *         written to, null
+     */
+    public static Path detectLocalFilePathForWriting(String path) {
+        if (isS3OrEmpty(path)) {
+            return null;
+        }
+        try {
+            Path filePath = parsePath(path);
+            // Valid if no parent component (relative to current dir) or parent exists
+            Path parent = filePath.getParent();
+            if (parent == null || Files.isDirectory(parent)) {
+                return filePath;
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean isS3OrEmpty(String path) {
+        return path == null || path.isEmpty() || path.startsWith(S3) || path.startsWith(S3A);
+    }
+
+    private static Path parsePath(String s3Path) throws URISyntaxException {
+        Path path;
+        if (s3Path.startsWith("file://")) {
+            path = Path.of(new URI(s3Path));
+        } else {
+            path = Path.of(s3Path);
+        }
+        return path;
+    }
+
+}

--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/SeekableCachedFooterReader.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/SeekableCachedFooterReader.java
@@ -119,8 +119,8 @@ class SeekableCachedFooterReader extends SeekableInputStream {
     }
 
     @Override
-    public boolean readVectoredAvailable(final ByteBufferAllocator allocator) {
-        return true;
+    public boolean readVectoredAvailable(ByteBufferAllocator allocator) {
+        return !allocator.isDirect();
     }
 
     private void checkOpen() throws IOException {

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3ContainerHelper.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3ContainerHelper.java
@@ -1,0 +1,54 @@
+package com.jerolba.carpet.io.s3;
+
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+class S3ContainerHelper {
+
+    static final String BUCKET_NAME = "test-bucket";
+
+    public static LocalStackContainer createS3LocalStackContainer() {
+        var localStack = new LocalStackContainer(DockerImageName.parse(
+                "localstack/localstack:s3-community-archive:b14111811a1071ff8e05ea2d89fac68dc3aa115bcb0b053f5502a1dfffba4ff8"))
+                        .withServices("s3");
+        localStack.start();
+
+        System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
+        System.setProperty("aws.accessKeyId", localStack.getAccessKey());
+        System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
+        System.setProperty("aws.region", localStack.getRegion());
+        return localStack;
+    }
+
+    public static S3Client createS3ClientWithBucket(LocalStackContainer localStack) {
+        S3Client s3Client = S3Client.builder()
+                .endpointOverride(localStack.getEndpoint())
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
+                .region(Region.of(localStack.getRegion()))
+                .build();
+        s3Client.createBucket(CreateBucketRequest.builder()
+                .bucket(BUCKET_NAME)
+                .build());
+        return s3Client;
+    }
+
+    public static void stopLocalStack(LocalStackContainer localStack) {
+        System.clearProperty("aws.endpointUrl");
+        System.clearProperty("aws.accessKeyId");
+        System.clearProperty("aws.secretAccessKey");
+        System.clearProperty("aws.region");
+
+        if (localStack != null) {
+            localStack.stop();
+        }
+    }
+
+}

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3ContainerHelper.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3ContainerHelper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jerolba.carpet.io.s3;
 
 import org.testcontainers.localstack.LocalStackContainer;

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3InputFileTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3InputFileTest.java
@@ -15,6 +15,10 @@
  */
 package com.jerolba.carpet.io.s3;
 
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.BUCKET_NAME;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3ClientWithBucket;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3LocalStackContainer;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.stopLocalStack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -23,11 +27,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.io.SeekableInputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,7 +43,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import com.jerolba.carpet.CarpetReader;
 import com.jerolba.carpet.CarpetWriter;
@@ -43,42 +50,21 @@ import com.jerolba.carpet.io.FileSystemOutputFile;
 
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 class S3InputFileTest {
-
-    private static final String BUCKET_NAME = "test-bucket";
 
     private static LocalStackContainer localStack;
 
     @BeforeAll
     static void setUp() {
-        localStack = new LocalStackContainer(DockerImageName.parse(
-                "localstack/localstack:s3-community-archive:b14111811a1071ff8e05ea2d89fac68dc3aa115bcb0b053f5502a1dfffba4ff8"))
-                        .withServices("s3");
-        localStack.start();
-        System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
-        System.setProperty("aws.accessKeyId", localStack.getAccessKey());
-        System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
-        System.setProperty("aws.region", localStack.getRegion());
-
-        try (S3Client s3Client = S3Client.create()) {
-            s3Client.createBucket(CreateBucketRequest.builder()
-                    .bucket(BUCKET_NAME)
-                    .build());
-        }
+        localStack = createS3LocalStackContainer();
+        createS3ClientWithBucket(localStack);
     }
 
     @AfterAll
     static void tearDown() {
-        if (localStack != null) {
-            localStack.stop();
-        }
-        System.clearProperty("aws.endpointUrl");
-        System.clearProperty("aws.accessKeyId");
-        System.clearProperty("aws.secretAccessKey");
-        System.clearProperty("aws.region");
+        stopLocalStack(localStack);
     }
 
     private static <T> byte[] writeParquetBytes(Class<T> recordClass, List<T> records) throws IOException {
@@ -127,29 +113,23 @@ class S3InputFileTest {
             String url = "s3://test-bucket/get-length-correct.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                assertEquals(parquetBytes.length, inputFile.getLength());
-            }
+            var inputFile = S3InputFile.of(url);
+            assertEquals(parquetBytes.length, inputFile.getLength());
         }
 
         @Test
         void getLengthThrowsForNonExistentKey() throws IOException {
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder("s3://test-bucket/non-existent-key.parquet").build();
-                var ex = assertThrows(IOException.class, inputFile::getLength);
-                assertTrue(ex.getMessage().contains("non-existent-key.parquet"));
-            }
+            var inputFile = S3InputFile.builder("s3://test-bucket/non-existent-key.parquet").build();
+            var ex = assertThrows(IOException.class, inputFile::getLength);
+            assertTrue(ex.getMessage().contains("non-existent-key.parquet"));
         }
 
         @Test
         void getLengthThrowsForNonExistentBucket() throws IOException {
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder().s3Client(s3Client).bucket("non-existent-bucket")
-                        .key("some-key.parquet").build();
-                var ex = assertThrows(IOException.class, inputFile::getLength);
-                assertTrue(ex.getMessage().contains("non-existent-bucket"));
-            }
+            var inputFile = S3InputFile.builder().bucket("non-existent-bucket")
+                    .key("some-key.parquet").build();
+            var ex = assertThrows(IOException.class, inputFile::getLength);
+            assertTrue(ex.getMessage().contains("non-existent-bucket"));
         }
     }
 
@@ -163,12 +143,10 @@ class S3InputFileTest {
             String url = "s3://test-bucket/new-stream-valid.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                try (SeekableInputStream stream = inputFile.newStream()) {
-                    assertNotNull(stream);
-                    assertEquals(0, stream.getPos());
-                }
+            var inputFile = S3InputFile.of(url);
+            try (SeekableInputStream stream = inputFile.newStream()) {
+                assertNotNull(stream);
+                assertEquals(0, stream.getPos());
             }
         }
 
@@ -179,15 +157,13 @@ class S3InputFileTest {
             String url = "s3://test-bucket/new-stream-independent.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                try (SeekableInputStream stream1 = inputFile.newStream();
-                        SeekableInputStream stream2 = inputFile.newStream()) {
-                    assertNotSame(stream1, stream2);
-                    stream1.seek(10);
-                    assertEquals(10, stream1.getPos());
-                    assertEquals(0, stream2.getPos());
-                }
+            var inputFile = S3InputFile.of(url);
+            try (SeekableInputStream stream1 = inputFile.newStream();
+                    SeekableInputStream stream2 = inputFile.newStream()) {
+                assertNotSame(stream1, stream2);
+                stream1.seek(10);
+                assertEquals(10, stream1.getPos());
+                assertEquals(0, stream2.getPos());
             }
         }
     }
@@ -204,11 +180,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-simple.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
 
         @Test
@@ -220,11 +194,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-multiple.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
 
         @Test
@@ -236,16 +208,14 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-stream-api.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                try (var stream = new CarpetReader<>(inputFile, SimpleRecord.class).stream()) {
-                    List<SimpleRecord> filtered = stream
-                            .filter(r -> r.id() >= 10 && r.id() < 20)
-                            .toList();
-                    assertEquals(10, filtered.size());
-                    assertEquals(10, filtered.get(0).id());
-                    assertEquals(19, filtered.get(9).id());
-                }
+            var inputFile = S3InputFile.of(url);
+            try (var stream = new CarpetReader<>(inputFile, SimpleRecord.class).stream()) {
+                List<SimpleRecord> filtered = stream
+                        .filter(r -> r.id() >= 10 && r.id() < 20)
+                        .toList();
+                assertEquals(10, filtered.size());
+                assertEquals(10, filtered.get(0).id());
+                assertEquals(19, filtered.get(9).id());
             }
         }
 
@@ -255,11 +225,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-empty.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertTrue(actual.isEmpty());
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertTrue(actual.isEmpty());
         }
 
         @Test
@@ -271,13 +239,11 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-projection.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<NarrowRecord> actual = new CarpetReader<>(inputFile, NarrowRecord.class).toList();
-                assertEquals(2, actual.size());
-                assertEquals(new NarrowRecord(1, "Alice"), actual.get(0));
-                assertEquals(new NarrowRecord(2, "Bob"), actual.get(1));
-            }
+            var inputFile = S3InputFile.of(url);
+            List<NarrowRecord> actual = new CarpetReader<>(inputFile, NarrowRecord.class).toList();
+            assertEquals(2, actual.size());
+            assertEquals(new NarrowRecord(1, "Alice"), actual.get(0));
+            assertEquals(new NarrowRecord(2, "Bob"), actual.get(1));
         }
 
         @Test
@@ -289,14 +255,12 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-large.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected.size(), actual.size());
-                assertEquals(expected.get(0), actual.get(0));
-                assertEquals(expected.get(expected.size() - 1), actual.get(actual.size() - 1));
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected.size(), actual.size());
+            assertEquals(expected.get(0), actual.get(0));
+            assertEquals(expected.get(expected.size() - 1), actual.get(actual.size() - 1));
+            assertEquals(expected, actual);
         }
     }
 
@@ -312,11 +276,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-concurrency-one.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
 
         @Test
@@ -328,11 +290,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-concurrency-multi.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder(url).s3Client(s3Client).concurrency(4).build();
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.builder(url).concurrency(4).build();
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
 
         @Test
@@ -344,16 +304,14 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-concurrency-both.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var sequential = S3InputFile.builder(url).concurrency(1).build();
-                var parallel = S3InputFile.builder(url).concurrency(4).build();
+            var sequential = S3InputFile.builder(url).concurrency(1).build();
+            var parallel = S3InputFile.builder(url).concurrency(4).build();
 
-                List<SimpleRecord> seqResult = new CarpetReader<>(sequential, SimpleRecord.class).toList();
-                List<SimpleRecord> parResult = new CarpetReader<>(parallel, SimpleRecord.class).toList();
+            List<SimpleRecord> seqResult = new CarpetReader<>(sequential, SimpleRecord.class).toList();
+            List<SimpleRecord> parResult = new CarpetReader<>(parallel, SimpleRecord.class).toList();
 
-                assertEquals(seqResult, parResult);
-                assertEquals(expected, seqResult);
-            }
+            assertEquals(seqResult, parResult);
+            assertEquals(expected, seqResult);
         }
     }
 
@@ -362,18 +320,14 @@ class S3InputFileTest {
 
         @Test
         void readFromNonExistentKeyThrows() throws IOException {
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder("s3://test-bucket/does-not-exist.parquet").build();
-                assertThrows(Exception.class, () -> new CarpetReader<>(inputFile, SimpleRecord.class).toList());
-            }
+            var inputFile = S3InputFile.builder("s3://test-bucket/does-not-exist.parquet").build();
+            assertThrows(Exception.class, () -> new CarpetReader<>(inputFile, SimpleRecord.class).toList());
         }
 
         @Test
         void readFromNonExistentBucketThrows() throws IOException {
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder("s3://no-such-bucket/some-key.parquet").build();
-                assertThrows(Exception.class, () -> new CarpetReader<>(inputFile, SimpleRecord.class).toList());
-            }
+            var inputFile = S3InputFile.builder("s3://no-such-bucket/some-key.parquet").build();
+            assertThrows(Exception.class, () -> new CarpetReader<>(inputFile, SimpleRecord.class).toList());
         }
     }
 
@@ -389,11 +343,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-small.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.of(url);
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
 
         @Test
@@ -405,11 +357,9 @@ class S3InputFileTest {
             String url = "s3://test-bucket/read-small-concurrent.parquet";
             uploadToS3(url, parquetBytes);
 
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder(url).s3Client(s3Client).concurrency(4).build();
-                List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
-                assertEquals(expected, actual);
-            }
+            var inputFile = S3InputFile.builder(url).concurrency(4).build();
+            List<SimpleRecord> actual = new CarpetReader<>(inputFile, SimpleRecord.class).toList();
+            assertEquals(expected, actual);
         }
     }
 
@@ -419,12 +369,17 @@ class S3InputFileTest {
 
         private static final int RECORD_COUNT = 400_000;
         private static final String LARGE_FILE_KEY = "large-file.parquet";
+        private static final String LARGE_FILE_URL = "s3://test-bucket/" + LARGE_FILE_KEY;
 
         record HeavyRecord(long id, long value, String payload) {
         }
 
-        private HeavyRecord firstRecord;
-        private HeavyRecord lastRecord;
+        record ProjectionRecord(long id, String payload) {
+        }
+
+        private final HeavyRecord firstRecord = new HeavyRecord(0, 0, makePayload(0));
+        private final HeavyRecord lastRecord = new HeavyRecord(RECORD_COUNT - 1, (RECORD_COUNT - 1) * 2,
+                makePayload(RECORD_COUNT - 1));
         private long uploadedSize;
 
         /**
@@ -444,16 +399,12 @@ class S3InputFileTest {
 
         @BeforeAll
         void setUpLargeFile() throws IOException {
-            firstRecord = new HeavyRecord(0, 0, makePayload(0));
-            lastRecord = new HeavyRecord(RECORD_COUNT - 1, (RECORD_COUNT - 1) * 2, makePayload(RECORD_COUNT - 1));
-
             // Write to a temp file with small row groups to avoid a 128 MiB row-group
             // buffer in heap. Rows are generated lazily and flushed to disk every 8 MiB.
             // createTempFile gives a unique path; delete the empty placeholder so
             // FileSystemOutputFile.create() (which requires a non-existing path) can work.
             Path tempFile = Files.createTempFile("large-parquet-test", ".parquet");
             Files.delete(tempFile);
-            String url = "s3://test-bucket/" + LARGE_FILE_KEY;
             try {
                 var outputFile = new FileSystemOutputFile(tempFile.toFile());
                 try (var writer = new CarpetWriter.Builder<>(outputFile, HeavyRecord.class)
@@ -466,7 +417,7 @@ class S3InputFileTest {
                 uploadedSize = Files.size(tempFile);
                 assertTrue(uploadedSize > 100L * 1024 * 1024,
                         "Expected parquet file > 100 MiB but was " + uploadedSize + " bytes");
-                uploadToS3(url, Files.readAllBytes(tempFile));
+                uploadToS3(LARGE_FILE_URL, Files.readAllBytes(tempFile));
             } finally {
                 Files.deleteIfExists(tempFile);
             }
@@ -474,67 +425,107 @@ class S3InputFileTest {
 
         @Test
         void getLengthReturnsCorrectSizeForLargeFile() throws IOException {
-            String url = "s3://test-bucket/large-file.parquet";
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.of(url);
-                assertEquals(uploadedSize, inputFile.getLength());
-            }
+            var inputFile = S3InputFile.of(LARGE_FILE_URL);
+            assertEquals(uploadedSize, inputFile.getLength());
         }
 
         @Test
         void readLargeFileWithSequentialReader() throws IOException {
-            String url = "s3://test-bucket/large-file.parquet";
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder(url).concurrency(1).build();
-                List<HeavyRecord> actual = new CarpetReader<>(inputFile, HeavyRecord.class).toList();
-                assertEquals(RECORD_COUNT, actual.size());
-                assertEquals(firstRecord, actual.get(0));
-                assertEquals(lastRecord, actual.get(RECORD_COUNT - 1));
-            }
+            var inputFile = S3InputFile.builder(LARGE_FILE_URL).concurrency(1).build();
+            List<HeavyRecord> actual = new CarpetReader<>(inputFile, HeavyRecord.class).toList();
+            assertEquals(RECORD_COUNT, actual.size());
+            assertEquals(firstRecord, actual.get(0));
+            assertEquals(lastRecord, actual.get(RECORD_COUNT - 1));
         }
 
         @Test
         void readLargeFileWithConcurrentReader() throws IOException {
-            String url = "s3://test-bucket/large-file.parquet";
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder(url).s3Client(s3Client).concurrency(4).build();
-                List<HeavyRecord> actual = new CarpetReader<>(inputFile, HeavyRecord.class).toList();
-                assertEquals(RECORD_COUNT, actual.size());
-                assertEquals(firstRecord, actual.get(0));
-                assertEquals(lastRecord, actual.get(RECORD_COUNT - 1));
-            }
-        }
-
-        @Test
-        void bothReadersReturnTheSameData() throws IOException {
-            String url = "s3://test-bucket/large-file.parquet";
-            try (var s3Client = S3Client.create()) {
-                var sequential = S3InputFile.builder(url).concurrency(1).build();
-                var concurrent = S3InputFile.builder(url).concurrency(4).build();
-
-                List<HeavyRecord> seqResult = new CarpetReader<>(sequential, HeavyRecord.class).toList();
-                List<HeavyRecord> parResult = new CarpetReader<>(concurrent, HeavyRecord.class).toList();
-
-                assertEquals(seqResult.size(), parResult.size());
-                assertEquals(seqResult.get(0), parResult.get(0));
-                assertEquals(seqResult.get(seqResult.size() - 1), parResult.get(parResult.size() - 1));
-            }
+            var inputFile = S3InputFile.builder(LARGE_FILE_URL).concurrency(4).build();
+            List<HeavyRecord> actual = new CarpetReader<>(inputFile, HeavyRecord.class).toList();
+            assertEquals(RECORD_COUNT, actual.size());
+            assertEquals(firstRecord, actual.get(0));
+            assertEquals(lastRecord, actual.get(RECORD_COUNT - 1));
         }
 
         @Test
         void readLargeFileWithProjection() throws IOException {
-            record ProjectionRecord(long id, String payload) {
+            var inputFile = S3InputFile.builder(LARGE_FILE_URL).concurrency(4).build();
+            List<ProjectionRecord> actual = new CarpetReader<>(inputFile, ProjectionRecord.class).toList();
+            assertEquals(RECORD_COUNT, actual.size());
+            assertEquals(firstRecord.id, actual.get(0).id);
+            assertEquals(firstRecord.payload, actual.get(0).payload);
+            assertEquals(lastRecord.id, actual.get(RECORD_COUNT - 1).id);
+            assertEquals(lastRecord.payload, actual.get(RECORD_COUNT - 1).payload);
+        }
+
+        @Test
+        void heapAllocatorConfigured() throws IOException {
+            var inputFile = S3InputFile.of(LARGE_FILE_URL);
+            var allocator = new ByteBufferAllocatorWrapper(HeapByteBufferAllocator.getInstance());
+            List<ProjectionRecord> actual = new CarpetReader.Builder<>(inputFile, ProjectionRecord.class)
+                    .withAllocator(allocator)
+                    .build()
+                    .toList();
+            assertEquals(RECORD_COUNT, actual.size());
+            assertEquals(firstRecord.id, actual.get(0).id);
+            assertEquals(firstRecord.payload, actual.get(0).payload);
+            assertEquals(lastRecord.id, actual.get(RECORD_COUNT - 1).id);
+            assertEquals(lastRecord.payload, actual.get(RECORD_COUNT - 1).payload);
+            assertEquals(22, allocator.allocationCount(),
+                    "Expected 22 ByteBuffer allocations for large file read with heap allocator");
+        }
+
+        @Test
+        void offHeapAllocatorConfigured() throws IOException {
+            var inputFile = S3InputFile.of(LARGE_FILE_URL);
+            var allocator = new ByteBufferAllocatorWrapper(DirectByteBufferAllocator.getInstance());
+            List<ProjectionRecord> actual = new CarpetReader.Builder<>(inputFile, ProjectionRecord.class)
+                    .withAllocator(allocator)
+                    .build()
+                    .toList();
+            assertEquals(RECORD_COUNT, actual.size());
+            assertEquals(firstRecord.id, actual.get(0).id);
+            assertEquals(firstRecord.payload, actual.get(0).payload);
+            assertEquals(lastRecord.id, actual.get(RECORD_COUNT - 1).id);
+            assertEquals(lastRecord.payload, actual.get(RECORD_COUNT - 1).payload);
+            // Off-heap allocator can not use vectorized reads, and fall backs to per page
+            // reads, resulting in more allocations. The exact number may vary based on
+            // parquet file structure and reader implementation details, but should be
+            // significantly higher than the heap allocator case.
+            assertEquals(63, allocator.allocationCount(),
+                    "Expected 63 ByteBuffer allocations for large file read with off-heap allocator");
+        }
+
+        private static class ByteBufferAllocatorWrapper implements ByteBufferAllocator {
+
+            private final ByteBufferAllocator delegate;
+            private long allocations = 0;
+
+            public ByteBufferAllocatorWrapper(ByteBufferAllocator delegate) {
+                this.delegate = delegate;
             }
-            String url = "s3://test-bucket/large-file.parquet";
-            try (var s3Client = S3Client.create()) {
-                var inputFile = S3InputFile.builder(url).s3Client(s3Client).concurrency(4).build();
-                List<ProjectionRecord> actual = new CarpetReader<>(inputFile, ProjectionRecord.class).toList();
-                assertEquals(RECORD_COUNT, actual.size());
-                assertEquals(firstRecord.id, actual.get(0).id);
-                assertEquals(firstRecord.payload, actual.get(0).payload);
-                assertEquals(lastRecord.id, actual.get(RECORD_COUNT - 1).id);
-                assertEquals(lastRecord.payload, actual.get(RECORD_COUNT - 1).payload);
+
+            @Override
+            public ByteBuffer allocate(int size) {
+                allocations++;
+                return delegate.allocate(size);
             }
+
+            @Override
+            public void release(ByteBuffer b) {
+                delegate.release(b);
+            }
+
+            @Override
+            public boolean isDirect() {
+                return delegate.isDirect();
+            }
+
+            public long allocationCount() {
+                return allocations;
+            }
+
         }
     }
+
 }

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileLocalTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileLocalTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.parquet.io.PositionOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.jerolba.carpet.CarpetReader;
+import com.jerolba.carpet.CarpetWriter;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class S3OutputFileLocalTest {
+
+    record SimpleRecord(long id, String name) {
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectLocalFileFromPath() throws IOException {
+        Path file = tempDir.resolve("output.parquet");
+
+        var outputFile = S3OutputFile.of(file.toString());
+        assertInstanceOf(LocalOutputFile.class, outputFile);
+    }
+
+    @Test
+    void detectLocalFileFromFileUri() throws IOException {
+        Path file = tempDir.resolve("output-uri.parquet");
+        URI uri = file.toUri();
+
+        var outputFile = S3OutputFile.of(uri.toString());
+        assertInstanceOf(LocalOutputFile.class, outputFile);
+    }
+
+    @Test
+    void s3PathIsNotDetectedAsLocal() {
+        S3Client mockClient = S3Client.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(() -> AwsBasicCredentials.create("foo", "bar"))
+                .endpointOverride(URI.create("http://localhost:8080"))
+                .build();
+        var outputFile = S3OutputFile.builder("s3://bucket/key").s3Client(mockClient).build();
+        assertInstanceOf(S3OutputFileImpl.class, outputFile);
+    }
+
+    @Test
+    void nonExistentParentDirectoryIsNotDetectedAsLocal() {
+        String nonExistentParent = tempDir.resolve("nonexistent").resolve("output.parquet").toString();
+        assertThrows(IllegalArgumentException.class, () -> S3OutputFile.of(nonExistentParent));
+    }
+
+    @Test
+    void localFileCreateWritesData() throws IOException {
+        Path file = tempDir.resolve("create-test.parquet");
+        var outputFile = S3OutputFile.of(file.toString());
+
+        var records = List.of(new SimpleRecord(1L, "Alice"), new SimpleRecord(2L, "Bob"));
+        try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(outputFile, SimpleRecord.class)) {
+            writer.write(records);
+        }
+
+        var actual = new CarpetReader<>(file.toFile(), SimpleRecord.class).toList();
+        assertEquals(records, actual);
+    }
+
+    @Test
+    void localFileCreateOrOverwriteReplacesExistingFile() throws IOException {
+        Path file = tempDir.resolve("overwrite-test.parquet");
+
+        var records1 = List.of(new SimpleRecord(1L, "Alice"));
+        try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(
+                S3OutputFile.builder(file.toString()).build(), SimpleRecord.class)) {
+            writer.write(records1);
+        }
+
+        var records2 = List.of(new SimpleRecord(2L, "Bob"), new SimpleRecord(3L, "Carol"));
+        try (PositionOutputStream out = S3OutputFile.builder(file.toString()).build()
+                .createOrOverwrite(0)) {
+            // createOrOverwrite should not throw even though the file already exists
+            assertDoesNotThrow(() -> {});
+        }
+
+        // Use CarpetWriter with createOrOverwrite via a second full write
+        var outputFile2 = new LocalOutputFile(file);
+        try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(outputFile2, SimpleRecord.class)) {
+            writer.write(records2);
+        }
+
+        var actual = new CarpetReader<>(file.toFile(), SimpleRecord.class).toList();
+        assertEquals(records2, actual);
+    }
+
+    @Test
+    void localFileCreateThrowsIfFileAlreadyExists() throws IOException {
+        Path file = tempDir.resolve("already-exists.parquet");
+        Files.write(file, new byte[] { 1, 2, 3 });
+
+        var outputFile = S3OutputFile.of(file.toString());
+        assertThrows(IOException.class, () -> outputFile.create(0));
+    }
+
+    @Test
+    void localFileGetPathReturnsFilePath() {
+        Path file = tempDir.resolve("getpath-test.parquet");
+        var outputFile = S3OutputFile.of(file.toString());
+        assertEquals(file.toString(), outputFile.getPath());
+    }
+
+    @Test
+    void positionTrackedCorrectly() throws IOException {
+        Path file = tempDir.resolve("position-test.parquet");
+        var outputFile = S3OutputFile.of(file.toString());
+
+        try (PositionOutputStream out = outputFile.createOrOverwrite(0)) {
+            assertEquals(0, out.getPos());
+            out.write(new byte[100]);
+            assertEquals(100, out.getPos());
+            out.write(new byte[50], 0, 50);
+            assertEquals(150, out.getPos());
+            out.write(42);
+            assertEquals(151, out.getPos());
+        }
+    }
+}

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
@@ -15,6 +15,10 @@
  */
 package com.jerolba.carpet.io.s3;
 
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.BUCKET_NAME;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3ClientWithBucket;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3LocalStackContainer;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.stopLocalStack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,49 +33,27 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import com.jerolba.carpet.CarpetReader;
 import com.jerolba.carpet.CarpetWriter;
 
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 class S3OutputFileTest {
 
-    private static final String BUCKET_NAME = "test-bucket";
-
     private static LocalStackContainer localStack;
 
     @BeforeAll
     static void setUp() {
-        localStack = new LocalStackContainer(DockerImageName.parse(
-                "localstack/localstack:s3-community-archive:b14111811a1071ff8e05ea2d89fac68dc3aa115bcb0b053f5502a1dfffba4ff8"))
-                        .withServices("s3");
-        localStack.start();
-        System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
-        System.setProperty("aws.accessKeyId", localStack.getAccessKey());
-        System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
-        System.setProperty("aws.region", localStack.getRegion());
-
-        try (S3Client s3Client = S3Client.create()) {
-            s3Client.createBucket(CreateBucketRequest.builder()
-                    .bucket(BUCKET_NAME)
-                    .build());
-        }
+        localStack = createS3LocalStackContainer();
+        createS3ClientWithBucket(localStack);
     }
 
     @AfterAll
     static void tearDown() {
-        if (localStack != null) {
-            localStack.stop();
-        }
-        System.clearProperty("aws.endpointUrl");
-        System.clearProperty("aws.accessKeyId");
-        System.clearProperty("aws.secretAccessKey");
-        System.clearProperty("aws.region");
+        stopLocalStack(localStack);
     }
 
     record SimpleRecord(long id, String name, double value) {

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.apache.parquet.io.PositionOutputStream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.jerolba.carpet.CarpetReader;
+import com.jerolba.carpet.CarpetWriter;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+class S3OutputFileTest {
+
+    private static final String BUCKET_NAME = "test-bucket";
+
+    private static LocalStackContainer localStack;
+
+    @BeforeAll
+    static void setUp() {
+        localStack = new LocalStackContainer(DockerImageName.parse(
+                "localstack/localstack:s3-community-archive:b14111811a1071ff8e05ea2d89fac68dc3aa115bcb0b053f5502a1dfffba4ff8"))
+                        .withServices("s3");
+        localStack.start();
+        System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
+        System.setProperty("aws.accessKeyId", localStack.getAccessKey());
+        System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
+        System.setProperty("aws.region", localStack.getRegion());
+
+        try (S3Client s3Client = S3Client.create()) {
+            s3Client.createBucket(CreateBucketRequest.builder()
+                    .bucket(BUCKET_NAME)
+                    .build());
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (localStack != null) {
+            localStack.stop();
+        }
+        System.clearProperty("aws.endpointUrl");
+        System.clearProperty("aws.accessKeyId");
+        System.clearProperty("aws.secretAccessKey");
+        System.clearProperty("aws.region");
+    }
+
+    record SimpleRecord(long id, String name, double value) {
+    }
+
+    record WideRecord(long id, String name, double value, int count, String description) {
+    }
+
+    record NarrowRecord(long id, String name) {
+    }
+
+    @Nested
+    class WriteAndRead {
+
+        @Test
+        void writeAndReadSimpleRecords() throws IOException {
+            var expected = List.of(
+                    new SimpleRecord(1, "Alice", 10.5),
+                    new SimpleRecord(2, "Bob", 20.3));
+            String url = "s3://test-bucket/write-read-simple.parquet";
+
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(expected);
+            }
+
+            List<SimpleRecord> actual = new CarpetReader<>(S3InputFile.of(url), SimpleRecord.class).toList();
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void writeAndReadMultipleRecords() throws IOException {
+            var expected = IntStream.range(0, 100)
+                    .mapToObj(i -> new SimpleRecord(i, "name-" + i, i * 1.1))
+                    .toList();
+            String url = "s3://test-bucket/write-read-multiple.parquet";
+
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(expected);
+            }
+
+            List<SimpleRecord> actual = new CarpetReader<>(S3InputFile.of(url), SimpleRecord.class).toList();
+            assertEquals(expected, actual);
+        }
+
+        @Test
+        void writeAndReadEmptyFile() throws IOException {
+            String url = "s3://test-bucket/write-read-empty.parquet";
+
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(List.of());
+            }
+
+            List<SimpleRecord> actual = new CarpetReader<>(S3InputFile.of(url), SimpleRecord.class).toList();
+            assertTrue(actual.isEmpty());
+        }
+
+        @Test
+        void writeAndReadWithProjection() throws IOException {
+            var records = List.of(
+                    new WideRecord(1, "Alice", 10.5, 42, "First"),
+                    new WideRecord(2, "Bob", 20.3, 99, "Second"));
+            String url = "s3://test-bucket/write-read-projection.parquet";
+
+            try (CarpetWriter<WideRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), WideRecord.class)) {
+                writer.write(records);
+            }
+
+            List<NarrowRecord> actual = new CarpetReader<>(S3InputFile.of(url), NarrowRecord.class).toList();
+            assertEquals(2, actual.size());
+            assertEquals(new NarrowRecord(1, "Alice"), actual.get(0));
+            assertEquals(new NarrowRecord(2, "Bob"), actual.get(1));
+        }
+    }
+
+    @Nested
+    class GetPath {
+
+        @Test
+        void getPathReturnS3Url() {
+            try (S3Client s3Client = S3Client.create()) {
+                var outputFile = S3OutputFile.builder("s3://test-bucket/get-path.parquet")
+                        .s3Client(s3Client).build();
+                assertEquals("s3://test-bucket/get-path.parquet", outputFile.getPath());
+            }
+        }
+    }
+
+    @Nested
+    class CreateBehavior {
+
+        @Test
+        void createThrowsIfObjectAlreadyExists() throws IOException {
+            String url = "s3://test-bucket/create-already-exists.parquet";
+
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(List.of(new SimpleRecord(1, "Alice", 1.0)));
+            }
+
+            var outputFile = S3OutputFile.of(url);
+            assertThrows(IOException.class, () -> outputFile.create(0));
+        }
+
+        @Test
+        void createOrOverwriteReplacesExistingObject() throws IOException {
+            String url = "s3://test-bucket/create-or-overwrite.parquet";
+            var first = List.of(new SimpleRecord(1, "Alice", 1.0));
+            var second = List.of(new SimpleRecord(2, "Bob", 2.0), new SimpleRecord(3, "Carol", 3.0));
+
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(first);
+            }
+
+            // CarpetWriter uses OVERWRITE mode, which calls createOrOverwrite
+            try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), SimpleRecord.class)) {
+                writer.write(second);
+            }
+
+            List<SimpleRecord> actual = new CarpetReader<>(S3InputFile.of(url), SimpleRecord.class).toList();
+            assertEquals(second, actual);
+        }
+    }
+
+    @Nested
+    class ErrorCases {
+
+        @Test
+        void writeToNonExistentBucketThrows() throws IOException {
+            var outputFile = S3OutputFile.builder("s3://no-such-bucket/some-key.parquet").build();
+            assertThrows(Exception.class, () -> {
+                try (CarpetWriter<SimpleRecord> writer = new CarpetWriter<>(outputFile, SimpleRecord.class)) {
+                    writer.write(List.of(new SimpleRecord(1, "Alice", 1.0)));
+                }
+            });
+        }
+    }
+
+    @Nested
+    class PositionTracking {
+
+        @Test
+        void positionIsTrackedCorrectly() throws IOException {
+            String url = "s3://test-bucket/position-tracking.parquet";
+            var outputFile = S3OutputFile.of(url);
+
+            try (PositionOutputStream out = outputFile.createOrOverwrite(0)) {
+                assertEquals(0, out.getPos());
+                out.write(new byte[100]);
+                assertEquals(100, out.getPos());
+                out.write(new byte[50], 0, 50);
+                assertEquals(150, out.getPos());
+                out.write(42);
+                assertEquals(151, out.getPos());
+            }
+        }
+    }
+
+    @Nested
+    class LargeFileScenarios {
+
+        /**
+         * Builds a 512-char incompressible string using a 32-bit LCG (same as
+         * S3InputFileTest) to keep the parquet file large enough to span multiple
+         * multipart upload parts (> 5 MiB each).
+         */
+        private static String makePayload(int seed) {
+            var sb = new StringBuilder(512 + 10);
+            int x = seed;
+            while (sb.length() < 512) {
+                x = x * 1664525 + 1013904223;
+                sb.append(Integer.toHexString(Integer.MAX_VALUE & x));
+            }
+            return sb.substring(0, 512);
+        }
+
+        record HeavyRecord(long id, long value, String payload) {
+        }
+
+        @Test
+        void writeLargeFileSpanningMultipleParts() throws IOException {
+            int recordCount = 40_000;
+            String url = "s3://test-bucket/write-large.parquet";
+
+            var expected = IntStream.range(0, recordCount)
+                    .mapToObj(i -> new HeavyRecord(i, i * 2L, makePayload(i)))
+                    .toList();
+
+            try (CarpetWriter<HeavyRecord> writer = new CarpetWriter<>(S3OutputFile.of(url), HeavyRecord.class)) {
+                writer.write(expected);
+            }
+
+            // Verify the object exists in S3 and has realistic size
+            try (S3Client s3Client = S3Client.create()) {
+                var head = s3Client.headObject(HeadObjectRequest.builder()
+                        .bucket(BUCKET_NAME)
+                        .key("write-large.parquet")
+                        .build());
+                assertTrue(head.contentLength() > S3OutputFileImpl.MIN_PART_SIZE,
+                        "Expected file larger than one multipart part, was: " + head.contentLength());
+            }
+
+            List<HeavyRecord> actual = new CarpetReader<>(S3InputFile.of(url), HeavyRecord.class).toList();
+            assertEquals(recordCount, actual.size());
+            assertEquals(expected.get(0), actual.get(0));
+            assertEquals(expected.get(recordCount - 1), actual.get(recordCount - 1));
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Nested
+    class AbortOnError {
+
+        @Test
+        void abortIsCalledWhenUploadFails() {
+            try (S3Client s3Client = S3Client.create()) {
+                // Force failure after multipart upload has been created but before any part can
+                // be completed, so close() must abort the multipart upload.
+                var outputFile = new S3OutputFileImpl(s3Client, BUCKET_NAME, "abort-test.parquet",
+                        runnable -> {
+                            throw new java.util.concurrent.RejectedExecutionException("forced test failure");
+                        });
+                assertThrows(Exception.class, () -> {
+                    try (PositionOutputStream out = outputFile.createOrOverwrite(0)) {
+                        // write enough to trigger a part upload (> 5 MiB)
+                        out.write(new byte[S3OutputFileImpl.MIN_PART_SIZE + 1]);
+                    }
+                });
+                // Verify the key was not left behind (upload was aborted)
+                try (S3Client goodClient = S3Client.create()) {
+                    assertThrows(NoSuchKeyException.class, () -> goodClient.headObject(
+                            HeadObjectRequest.builder()
+                                    .bucket(BUCKET_NAME)
+                                    .key("abort-test.parquet")
+                                    .build()));
+                }
+            }
+        }
+    }
+}

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3SeekableReaderTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3SeekableReaderTest.java
@@ -15,6 +15,10 @@
  */
 package com.jerolba.carpet.io.s3;
 
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.BUCKET_NAME;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3ClientWithBucket;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.createS3LocalStackContainer;
+import static com.jerolba.carpet.io.s3.S3ContainerHelper.stopLocalStack;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,19 +34,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 class S3SeekableReaderTest {
 
-    private static final String BUCKET_NAME = "test-bucket";
     private static final String OBJECT_KEY = "test-object.parquet";
 
     private static LocalStackContainer localStack;
@@ -51,22 +49,8 @@ class S3SeekableReaderTest {
 
     @BeforeAll
     static void setUp() {
-        localStack = new LocalStackContainer(DockerImageName.parse(
-                "localstack/localstack:s3-community-archive:b14111811a1071ff8e05ea2d89fac68dc3aa115bcb0b053f5502a1dfffba4ff8"))
-                        .withServices("s3");
-        localStack.start();
-
-        s3Client = S3Client.builder()
-                .endpointOverride(localStack.getEndpoint())
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
-                .region(Region.of(localStack.getRegion()))
-                .build();
-
-        s3Client.createBucket(CreateBucketRequest.builder()
-                .bucket(BUCKET_NAME)
-                .build());
+        localStack = createS3LocalStackContainer();
+        s3Client = createS3ClientWithBucket(localStack);
 
         // Create test data with sequential bytes
         testData = new byte[1024];
@@ -79,12 +63,7 @@ class S3SeekableReaderTest {
 
     @AfterAll
     static void tearDown() {
-        if (s3Client != null) {
-            s3Client.close();
-        }
-        if (localStack != null) {
-            localStack.stop();
-        }
+        stopLocalStack(localStack);
     }
 
     @Test

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3UrlParsingTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3UrlParsingTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2023 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jerolba.carpet.io.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class S3UrlParsingTest {
+
+    @Test
+    void parseS3Url() {
+        S3UrlParsing.S3Path s3Path = S3UrlParsing.parses3Url("s3://bucket/key");
+        assertEquals("bucket", s3Path.bucket());
+        assertEquals("key", s3Path.key());
+
+        s3Path = S3UrlParsing.parses3Url("s3a://bucket/key/with/slashes");
+        assertEquals("bucket", s3Path.bucket());
+        assertEquals("key/with/slashes", s3Path.key());
+
+        s3Path = S3UrlParsing.parses3Url("s3://bucket-123.region/complex/key-_123");
+        assertEquals("bucket-123.region", s3Path.bucket());
+        assertEquals("complex/key-_123", s3Path.key());
+    }
+
+    @Test
+    void parseS3UrlInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url(null));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url(""));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("http://bucket/key"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3://bucket"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3://bucket/"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3a://bucket/"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3://"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3a://"));
+        assertThrows(IllegalArgumentException.class, () -> S3UrlParsing.parses3Url("s3:/bucket/key"));
+    }
+
+    @Test
+    void detectLocalFilePathForReading(@TempDir Path tempDir) throws IOException {
+        Path existingFile = tempDir.resolve("test.txt");
+        Files.writeString(existingFile, "content");
+        Path nonExistingFile = tempDir.resolve("non-existing.txt");
+        Path existingDir = tempDir.resolve("subdir");
+        Files.createDirectory(existingDir);
+
+        assertEquals(existingFile, S3UrlParsing.detectLocalFilePathForReading(existingFile.toString()));
+        assertEquals(existingDir, S3UrlParsing.detectLocalFilePathForReading(existingDir.toString()));
+        assertNull(S3UrlParsing.detectLocalFilePathForReading(nonExistingFile.toString()));
+        assertNull(S3UrlParsing.detectLocalFilePathForReading("s3://bucket/key"));
+        assertNull(S3UrlParsing.detectLocalFilePathForReading("s3a://bucket/key"));
+        assertNull(S3UrlParsing.detectLocalFilePathForReading(null));
+        assertNull(S3UrlParsing.detectLocalFilePathForReading(""));
+    }
+
+    @Test
+    void detectLocalFilePathForReadingWithFileUri(@TempDir Path tempDir) throws IOException {
+        Path existingFile = tempDir.resolve("test.txt");
+        Files.writeString(existingFile, "content");
+
+        String fileUri = existingFile.toUri().toString();
+        assertEquals(existingFile, S3UrlParsing.detectLocalFilePathForReading(fileUri));
+
+        assertNull(S3UrlParsing.detectLocalFilePathForReading("file:///non-existing-path-xyz-123"));
+    }
+
+    @Test
+    void detectLocalFilePathForWriting(@TempDir Path tempDir) {
+        Path fileInExistingDir = tempDir.resolve("newfile.txt");
+        Path fileInNonExistingDir = tempDir.resolve("non-existing-dir/newfile.txt");
+
+        assertEquals(fileInExistingDir, S3UrlParsing.detectLocalFilePathForWriting(fileInExistingDir.toString()));
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting(fileInNonExistingDir.toString()));
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting("s3://bucket/key"));
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting("s3a://bucket/key"));
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting(null));
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting(""));
+    }
+
+    @Test
+    void detectLocalFilePathForWritingWithFileUri(@TempDir Path tempDir) {
+        Path fileInExistingDir = tempDir.resolve("newfile.txt");
+        String fileUri = fileInExistingDir.toUri().toString();
+        assertEquals(fileInExistingDir, S3UrlParsing.detectLocalFilePathForWriting(fileUri));
+
+        Path fileInNonExistingDir = tempDir.resolve("subdir/newfile.txt");
+        String fileUriInNonExistingDir = fileInNonExistingDir.toUri().toString();
+        assertNull(S3UrlParsing.detectLocalFilePathForWriting(fileUriInNonExistingDir));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version = 0.7.0-SNAPSHOT
 parquetVersion = 1.17.0
 hadoopVersion = 3.4.1
 junitVersion = 6.0.3
+awsSdkVersion = 2.42.27
 
 mavenCentralPublishing=true
 signAllPublications=true


### PR DESCRIPTION
This pull request introduces S3 output file support to the project, allowing seamless writing to both S3 and local files using a unified interface. It adds a new `S3OutputFile` abstraction, its S3 and local implementations, and refactors S3 path parsing and local file detection logic into a shared utility.
