### PR TITLE
#168 S3 multipart upload must have fixed size

### DIFF
--- a/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFileImpl.java
+++ b/carpet-s3/src/main/java/com/jerolba/carpet/io/s3/S3OutputFileImpl.java
@@ -18,6 +18,7 @@ package com.jerolba.carpet.io.s3;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -192,23 +193,27 @@ class S3OutputFileImpl implements S3OutputFile {
 
         private void flushPartIfNeeded() {
             if (partBuffer.size() >= MIN_PART_SIZE) {
-                uploadPart();
+                uploadPart(partBuffer, MIN_PART_SIZE);
             }
         }
 
         private void flushFinalPart() {
             if (partBuffer.size() > 0) {
-                uploadPart();
+                uploadPart(partBuffer, partBuffer.size());
             }
         }
 
-        private void uploadPart() {
+        private void uploadPart(ByteArrayOutputStream buffer, int lengthToUpload) {
             int partNumber = futures.size() + 1;
-            byte[] data = partBuffer.toByteArray();
-            partBuffer.reset();
-            long partStartPos = pos - data.length;
+            byte[] allData = buffer.toByteArray();
+            buffer.reset();
+            byte[] toUploadData = Arrays.copyOf(allData, lengthToUpload);
+            if (allData.length > lengthToUpload) {
+                buffer.write(allData, lengthToUpload, allData.length - lengthToUpload);
+            }
+            long partStartPos = pos - allData.length;
             CompletableFuture<CompletedPart> future = CompletableFuture.supplyAsync(
-                    () -> uploadPartS3(partNumber, partStartPos, data), executor);
+                    () -> uploadPartS3(partNumber, partStartPos, toUploadData), executor);
             futures.add(future);
         }
 

--- a/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
+++ b/carpet-s3/src/test/java/com/jerolba/carpet/io/s3/S3OutputFileTest.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 
 import org.apache.parquet.io.PositionOutputStream;
@@ -229,6 +231,48 @@ class S3OutputFileTest {
         }
 
         record HeavyRecord(long id, long value, String payload) {
+        }
+
+        @Test
+        void intermediatePartsAreExactlyMinPartSize() throws IOException {
+            var partSizes = new CopyOnWriteArrayList<Long>();
+            S3Client realClient = S3Client.create();
+            S3Client capturingClient = (S3Client) Proxy.newProxyInstance(
+                    S3Client.class.getClassLoader(),
+                    new Class<?>[] { S3Client.class },
+                    (proxy, method, args) -> {
+                        if ("uploadPart".equals(method.getName()) && args.length == 2) {
+                            var requestBody = (software.amazon.awssdk.core.sync.RequestBody) args[1];
+                            partSizes.add(requestBody.optionalContentLength().orElseThrow());
+                        }
+                        return method.invoke(realClient, args);
+                    });
+
+            int recordCount = 40_000;
+            String key = "part-size-test.parquet";
+
+            var expected = IntStream.range(0, recordCount)
+                    .mapToObj(i -> new HeavyRecord(i, i * 2L, makePayload(i)))
+                    .toList();
+
+            try (CarpetWriter<HeavyRecord> writer = new CarpetWriter<>(
+                    S3OutputFile.builder(BUCKET_NAME, key).s3Client(capturingClient).build(), HeavyRecord.class)) {
+                writer.write(expected);
+            }
+
+            assertTrue(partSizes.size() >= 3,
+                    "Expected at least 3 parts, got: " + partSizes.size());
+            assertEquals(S3OutputFileImpl.MIN_PART_SIZE, partSizes.get(0).longValue(),
+                    "First part should be exactly MIN_PART_SIZE");
+            assertEquals(S3OutputFileImpl.MIN_PART_SIZE, partSizes.get(1).longValue(),
+                    "Second part should be exactly MIN_PART_SIZE");
+
+            List<HeavyRecord> actual = new CarpetReader<>(S3InputFile.builder(BUCKET_NAME, key).build(),
+                    HeavyRecord.class).toList();
+            assertEquals(recordCount, actual.size());
+            assertEquals(expected, actual);
+
+            realClient.close();
         }
 
         @Test


### PR DESCRIPTION
Cloudflare R2 enforces to use always the same size on each part (except the latest)

Make part size configurable, using as default value 1/4 of rowgroup size to avoid multiple but small request